### PR TITLE
feat: [BE] VPL同期: users・courses / Đồng bộ users & courses

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 
@@ -18,6 +18,7 @@ model User {
   externalId   String?  // 外部システム連携用
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  deletedAt    DateTime? // IC soft-delete 連携用（将来用）
 
   createdRecordHistories MonthlyRecordHistory[]
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,7 +14,7 @@ app.use(
   })
 );
 app.use(cookieParser());
-app.use(express.json());
+app.use(express.json({ limit: "5mb" }));
 
 app.use("/api", apiRouter);
 

--- a/backend/src/routes/courses.ts
+++ b/backend/src/routes/courses.ts
@@ -56,13 +56,20 @@ coursesRouter.post("/sync", requireRole(ROLES.MASTER), async (req: Request, res:
         externalId: externalId ? String(externalId).trim() : null,
       };
 
-      const existing = externalId
-        ? await prisma.course.findFirst({ where: { externalId: String(externalId) } })
-        : await prisma.course.findUnique({
-            where: {
-              locationId_code: { locationId: locId, code: codeStr },
-            },
-          });
+      // Prefer externalId; if missing in VPL but (locationId, code) exists (e.g. re-sync / IC id change), match by composite key to avoid P2002 on create.
+      let existing = null;
+      if (externalId) {
+        existing = await prisma.course.findFirst({
+          where: { externalId: String(externalId).trim() },
+        });
+      }
+      if (!existing) {
+        existing = await prisma.course.findUnique({
+          where: {
+            locationId_code: { locationId: locId, code: codeStr },
+          },
+        });
+      }
 
       if (existing) {
         const updated = await prisma.course.update({

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -201,7 +201,7 @@ usersRouter.post("/sync", async (req: Request, res: Response) => {
     const results: { email: string; status: "created" | "updated"; id: string }[] = [];
 
     for (const u of users) {
-      const { email, name, role, externalId, userId, password } = u;
+      const { email, name, role, externalId, userId, password, createdAt, updatedAt } = u;
       const extId = externalId ?? userId;
       if (!email || !name || !role) continue;
       if (!VALID_ROLES.includes(role)) continue;
@@ -210,12 +210,17 @@ usersRouter.post("/sync", async (req: Request, res: Response) => {
         ? await bcrypt.hash(String(password), 10)
         : await bcrypt.hash("changeme", 10);
 
+      const timestamps: Record<string, Date> = {};
+      if (createdAt) timestamps.createdAt = new Date(createdAt);
+      if (updatedAt) timestamps.updatedAt = new Date(updatedAt);
+
       const data = {
         email: String(email).trim(),
         name: String(name).trim(),
         role: String(role),
         externalId: extId ? String(extId).trim() : null,
         passwordHash,
+        ...timestamps,
       };
 
       const existing = extId
@@ -230,6 +235,8 @@ usersRouter.post("/sync", async (req: Request, res: Response) => {
             role: data.role,
             externalId: data.externalId,
             ...(password && { passwordHash: data.passwordHash }),
+            ...(createdAt && { createdAt: new Date(createdAt) }),
+            ...(updatedAt && { updatedAt: new Date(updatedAt) }),
           },
         });
         results.push({ email: data.email, status: "updated", id: updated.id });

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown-summary.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown-summary.md
@@ -1,0 +1,20 @@
+# Breakdown — Issue #956 (GitHub)
+
+Parent: https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/956  
+
+Project V2: **Izumi_Issue** (`PVT_kwDOCjwUv84Ajq0M`) — child issues đã add + cột **SP** (TEXT).
+
+| # | SP (h) | Title (short) |
+|---|--------|----------------|
+| [#966](https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/966) | 8 | VPL 基盤: HTTP / JWT / Artisan |
+| [#967](https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/967) | 8 | users + courses sync |
+| [#968](https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/968) | 8 | vehicles + drivers sync |
+| [#969](https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/969) | 13 | vehicle-monthly-costs + ITP |
+| [#970](https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/970) | 8 | location-monthly-expenses + PCA |
+| [#971](https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/971) | 8 | import/bulk + E2E + doc |
+
+**Tổng SP:** 53 (1 SP = 1 giờ theo convention breakdown / skill).
+
+Body templates đã dùng: `breakdown/child-0N-body.md`.
+
+**Lưu ý:** Không có issue FE — scope #956 là client Laravel (BE) gọi API VPL.

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-01-body.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-01-body.md
@@ -1,0 +1,53 @@
+## 日本語 / Japanese
+
+### 親Issue
+Parent: #956
+
+### 説明
+Izumi Cloud から VPL（vehicle-pl-system）へ同期するための**基盤**を実装する。HTTP クライアント、`POST /api/auth/login` による JWT 取得・キャッシュ・401 時の再ログイン、Artisan コマンド（例: `vpl:sync`）のエントリ、`--entity` / `--year-month` / `--dry-run` の骨格、日次ログ（`storage`、専用 channel 推奨）、HTTP エラー（400/401/403/500）と最小限のリトライ方針。
+
+### 要件
+- `docs/issues/Izumi_Issue-Requests-Repo/956/plan.md` Phase 0–1 に準拠
+- Base URL は環境別（VPL は legacy `BASE_URL_PL` と混同しない）
+- 秘密情報は `.env` のみ
+
+### 技術詳細
+- 実装リポジトリ: **izumi-cloud**（Laravel）
+- 参照: `vehicle-pl-system/docs/external-integration-spec.md`（認証）
+
+### 受け入れ基準
+- [ ] 実装完了
+- [ ] ユニットテスト作成・合格（クライアント・トークン周り）
+- [ ] プロジェクト規約に準拠
+- [ ] 既存機能への破壊的変更なし
+
+### 依存関係
+なし（他子 Issue の前提）
+
+---
+
+## Tiếng Việt / Vietnamese
+
+### Issue cha
+Parent: #956
+
+### Mô tả
+Triển khai **nền tảng** đồng bộ từ Izumi Cloud sang VPL: HTTP client, JWT qua `POST /api/auth/login`, cache token và login lại khi 401, Artisan command (`vpl:sync` hoặc tương đương), option `--entity` / `--year-month` / `--dry-run`, log theo ngày vào `storage` (nên dùng channel riêng), xử lý lỗi HTTP và retry tối thiểu.
+
+### Yêu cầu
+- Theo `plan.md` Phase 0–1
+- Base URL theo môi trường; không nhầm VPL với `BASE_URL_PL`
+- Secret chỉ trong `.env`
+
+### Chi tiết kỹ thuật
+- Code chính: **izumi-cloud** (Laravel)
+- Tham chiếu: `external-integration-spec.md` (auth)
+
+### Tiêu chí chấp nhận
+- [ ] Hoàn thành triển khai
+- [ ] Unit test (client, token)
+- [ ] Tuân thủ quy ước dự án
+- [ ] Không phá vỡ chức năng hiện có
+
+### Phụ thuộc
+Không

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-02-body.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-02-body.md
@@ -1,0 +1,51 @@
+## 日本語 / Japanese
+
+### 親Issue
+Parent: #956
+
+### 説明
+`POST /api/users/sync` と `POST /api/courses/sync` の ETL・呼び出しを実装する。`departmentId` は `LOC` + `departments.id` を 3 桁ゼロ埋め。コース `name` は IC に列がないため plan / `ic-sync-field-mapping.md` に従い生成。`externalId` は IC の `id`。Spatie role → VPL `VALID_ROLES` のマッピング。
+
+### 要件
+- `ic-sync-field-mapping.md` §1–2
+- PHPUnit（サービス／トランスフォーマ）
+
+### 技術詳細
+- リポジトリ: **izumi-cloud**
+- 依存: 子 Issue「VPL 基盤」（JWT・クライアント）
+
+### 受け入れ基準
+- [ ] 実装完了
+- [ ] ユニットテスト作成・合格
+- [ ] プロジェクト規約に準拠
+- [ ] 既存機能への破壊的変更なし
+
+### 依存関係
+子 Issue #（VPL 基盤）マージ後に結合テスト可能
+
+---
+
+## Tiếng Việt / Vietnamese
+
+### Issue cha
+Parent: #956
+
+### Mô tả
+ETL và gọi `POST /api/users/sync`, `POST /api/courses/sync`. `departmentId` = `LOC` + pad 3 `departments.id`. Tạo `name` cho course theo mapping doc. `externalId` = id IC. Map role Spatie → `VALID_ROLES` VPL.
+
+### Yêu cầu
+- `ic-sync-field-mapping.md` §1–2
+- PHPUnit
+
+### Chi tiết kỹ thuật
+- **izumi-cloud**
+- Phụ thuộc: issue con nền tảng (client + JWT)
+
+### Tiêu chí chấp nhận
+- [ ] Hoàn thành triển khai
+- [ ] Unit test đạt
+- [ ] Tuân thủ quy ước
+- [ ] Không breaking change
+
+### Phụ thuộc
+Sau khi có client/JWT từ issue nền tảng

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-03-body.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-03-body.md
@@ -1,0 +1,51 @@
+## 日本語 / Japanese
+
+### 親Issue
+Parent: #956
+
+### 説明
+`POST /api/vehicles/sync` と `POST /api/drivers/sync` を実装する。車両: `latestNumberPlateHistory` から `vehicleNo`、`departmentId` は LOC 規則、`courseExternalId` は未取得時 null 可。ドライバー: `employees`、多対多 department から主所属を決めて LOC へ。N+1 回避（500+ 台想定）。
+
+### 要件
+- `ic-sync-field-mapping.md` §3–4
+- PHPUnit
+
+### 技術詳細
+- **izumi-cloud**
+- 推奨順: courses 同期後に vehicles
+
+### 受け入れ基準
+- [ ] 実装完了
+- [ ] ユニットテスト作成・合格
+- [ ] プロジェクト規約に準拠
+- [ ] 既存機能への破壊的変更なし
+
+### 依存関係
+VPL 基盤。vehicles は courses 同期とデータ整合が望ましい
+
+---
+
+## Tiếng Việt / Vietnamese
+
+### Issue cha
+Parent: #956
+
+### Mô tả
+`vehicles/sync` và `drivers/sync`. Xe: `vehicleNo` từ `latestNumberPlateHistory`, `departmentId` theo LOC, `courseExternalId` nullable. Driver: `employees`, chọn department chính từ quan hệ N-N → LOC. Tránh N+1.
+
+### Yêu cầu
+- `ic-sync-field-mapping.md` §3–4
+- PHPUnit
+
+### Chi tiết kỹ thuật
+- **izumi-cloud**
+- Nên sync courses trước vehicles
+
+### Tiêu chí chấp nhận
+- [ ] Hoàn thành
+- [ ] Unit test
+- [ ] Quy ước dự án
+- [ ] Không breaking change
+
+### Phụ thuộc
+Nền tảng VPL; vehicles sau courses (khuyến nghị)

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-04-body.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-04-body.md
@@ -1,0 +1,51 @@
+## 日本語 / Japanese
+
+### 親Issue
+Parent: #956
+
+### 説明
+`POST /api/vehicle-monthly-costs/sync` を実装する。IC 側 DB（MaintenanceLease、InsuranceRate 等）からの集計と、**ITP API** からの `fuelEfficiency` / `roadUsageFee` をマージ。`yearMonth` パラメータ対応。
+
+### 要件
+- plan Phase 3、`ic-sync-field-mapping.md` §5
+- PHPUnit（モック ITP を含む）
+
+### 技術詳細
+- **izumi-cloud**（ITP プロキシ／クライアント）
+- 外部依存が大きいため不確実性にバッファ済み（SP: 13）
+
+### 受け入れ基準
+- [ ] 実装完了
+- [ ] ユニットテスト作成・合格
+- [ ] プロジェクト規約に準拠
+- [ ] 既存機能への破壊的変更なし
+
+### 依存関係
+VPL 基盤、vehicles 同期（`vehicleExternalId` 整合）
+
+---
+
+## Tiếng Việt / Vietnamese
+
+### Issue cha
+Parent: #956
+
+### Mô tả
+`vehicle-monthly-costs/sync`: tổng hợp từ bảng IC + gọi **ITP** cho `fuelEfficiency`, `roadUsageFee`; tham số `yearMonth`.
+
+### Yêu cầu
+- plan Phase 3, `ic-sync-field-mapping.md` §5
+- PHPUnit (mock ITP)
+
+### Chi tiết kỹ thuật
+- **izumi-cloud**
+- SP 13 do phụ thuộc ITP
+
+### Tiêu chí chấp nhận
+- [ ] Hoàn thành
+- [ ] Unit test
+- [ ] Quy ước
+- [ ] Không breaking
+
+### Phụ thuộc
+Nền tảng + vehicles sync (khớp externalId)

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-05-body.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-05-body.md
@@ -1,0 +1,51 @@
+## 日本語 / Japanese
+
+### 親Issue
+Parent: #956
+
+### 説明
+`POST /api/location-monthly-expenses/sync` を実装する。PCA データ（例: `pl_pca_data`）から `yearMonth`、`departmentId`（LOC 規則）、`accountItemCode`（PCA → VPL 20 科目 6150–6189）、`amount` をマッピング。
+
+### 要件
+- plan Phase 3、`ic-sync-field-mapping.md` §6
+- PHPUnit
+
+### 技術詳細
+- **izumi-cloud**
+- BA/経理による PCA コード対応表の確定が前提
+
+### 受け入れ基準
+- [ ] 実装完了
+- [ ] ユニットテスト作成・合格
+- [ ] プロジェクト規約に準拠
+- [ ] 既存機能への破壊的変更なし
+
+### 依存関係
+VPL 基盤
+
+---
+
+## Tiếng Việt / Vietnamese
+
+### Issue cha
+Parent: #956
+
+### Mô tả
+`location-monthly-expenses/sync`: PCA → payload với `yearMonth`, `departmentId` (LOC), map `accountItemCode` PCA → 20 mã VPL, `amount`.
+
+### Yêu cầu
+- plan Phase 3, `ic-sync-field-mapping.md` §6
+- PHPUnit
+
+### Chi tiết kỹ thuật
+- **izumi-cloud**
+- Cần bảng map PCA do BA/kế toán
+
+### Tiêu chí chấp nhận
+- [ ] Hoàn thành
+- [ ] Unit test
+- [ ] Quy ước
+- [ ] Không breaking
+
+### Phụ thuộc
+Nền tảng VPL

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-06-body.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/breakdown/child-06-body.md
@@ -1,0 +1,50 @@
+## 日本語 / Japanese
+
+### 親Issue
+Parent: #956
+
+### 説明
+経理連携を **どちらか一方** 先に実装: `POST /api/import`（multipart）**または** `POST /api/income-statement/records/bulk`（JSON）。IC 側データソース（ファイル vs DB）と **EDIT_PL** ユーザーを確定。最小 E2E（local）と `dev.md` 更新、known limitations 記載。
+
+### 要件
+- plan Phase 4–5
+- ユニットテスト＋手動 E2E 観点
+
+### 技術詳細
+- **izumi-cloud**
+- VPL 側 API は既存仕様に準拠
+
+### 受け入れ基準
+- [ ] 実装完了
+- [ ] ユニットテスト作成・合格
+- [ ] プロジェクト規約に準拠
+- [ ] 既存機能への破壊的変更なし
+
+### 依存関係
+VPL 基盤。master 同期後のデータがあると検証しやすい
+
+---
+
+## Tiếng Việt / Vietnamese
+
+### Issue cha
+Parent: #956
+
+### Mô tả
+Triển khai **một** trong hai: `import` (multipart) **hoặc** `income-statement/records/bulk`. Chốt nguồn IC và user **EDIT_PL**. E2E tối thiểu, cập nhật `dev.md`, ghi hạn chế.
+
+### Yêu cầu
+- plan Phase 4–5
+- Unit test + kịch bản E2E thủ công
+
+### Chi tiết kỹ thuật
+- **izumi-cloud**
+
+### Tiêu chí chấp nhận
+- [ ] Hoàn thành
+- [ ] Unit test
+- [ ] Quy ước
+- [ ] Không breaking
+
+### Phụ thuộc
+Nền tảng; có master sync thì test dễ hơn

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/ic-sync-field-mapping.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/ic-sync-field-mapping.md
@@ -1,0 +1,71 @@
+# Phân tích Ánh xạ Dữ liệu Đồng bộ (Data Mapping) từ Izumi Cloud sang VPL (Issue #956)
+
+Tài liệu này chi tiết hóa cách "lắp ráp" và biến đổi (transform) từng field dữ liệu cho các API đồng bộ Master Sync từ hệ thống Izumi Cloud (IC) sang hệ thống VPL.
+
+## 1. Đồng bộ Người dùng (POST `/api/users/sync`)
+Gửi danh sách User từ IC sang VPL.
+
+| Field y/cầu của VPL | Nguồn dữ liệu bên IC (Bảng `users`) | Logic Transform (Biến đổi) tại IC |
+| :--- | :--- | :--- |
+| `userId` | `$user->id` (hoặc `uuid`) | Không cần đổi, lấy ID nguyên bản làm `externalId` cho VPL. |
+| `email` | `$user->email` | Map trực tiếp 1-1. |
+| `name` | `$user->name` | Map trực tiếp 1-1. |
+| `role` | `$user->roles` (Spatie) | **[CẦN BIẾN ĐỔI]** Phải viết hàm chuyển đổi từ Role của IC sang đúng Enum tiếng Nhật của VPL (Vd: `CREW`, `DX`, `経理財務`). |
+| `password` | `$user->password` | Tùy chọn. Tốt nhất là bỏ trống hoặc truyền chuỗi mặc định, VPL sẽ tự mã hóa. |
+
+## 2. Đồng bộ Khóa học / Tuyến đường (POST `/api/courses/sync`)
+Lưu ý IC không lưu cấu trúc `Course` hoàn toàn giống VPL.
+
+| Field y/cầu của VPL | Nguồn dữ liệu bên IC (Bảng `courses`) | Logic Transform (Biến đổi) tại IC |
+| :--- | :--- | :--- |
+| `departmentId` | `$course->department_id` | **[CẦN BIẾN ĐỔI]** Phải tra bảng `departments` lấy mã String nội bộ (Ví dụ: ID `1` -> `"LOC001"`). |
+| `code` | `$course->course_code` | Map trực tiếp 1-1. |
+| `name` | Không có sẵn cột `name` | **[CẦN BIẾN ĐỔI]** VPL bắt buộc trường `name`. IC phải tự nối chuỗi (Ví dụ `$course->course_type . ' - ' . $course->address`) để tạo tên có nghĩa. |
+| `sortOrder` | Không có | Có thể truyền mặc định `0`, VPL sẽ tự động tăng dần (Auto-increment). |
+| `externalId` | `$course->id` | ID gốc để VPL dùng cho tính năng UPSERT. |
+
+## 3. Đồng bộ Phương tiện (POST `/api/vehicles/sync`)
+Đây là API cần transform nhiều nhất do IC lưu tách rời thông tin biển số.
+
+| Field y/cầu của VPL | Nguồn dữ liệu bên IC (Bảng `vehicles`) | Logic Transform (Biến đổi) tại IC |
+| :--- | :--- | :--- |
+| `departmentId` | `$vehicle->department_id` | Map ID số nguyên sang Array Mã String (Vd `"LOC001"`). |
+| `vehicleNo` | `latestNumberPlateHistory()` | **[CẦN BIẾN ĐỔI]** Cột `vehicles` của IC không có biển số xe trực tiếp. Phải load relation `latestNumberPlateHistory` và lấy ra biển số mới nhất. |
+| `serviceType` | `$vehicle->truck_classification` | Dùng phân loại xe của IC (hoặc `driving_classification`) để map sang. |
+| `tonnage` | `$vehicle->tonnage` | Map trực tiếp 1-1 (VPL dùng để tính phí bảo hiểm tải trọng). |
+| `externalId` | `$vehicle->id` | ID nội bộ IC. |
+| `courseExternalId`| Khóa ngoại hoặc mảng phân công | **[CẦN BIẾN ĐỔI]** Bảng xe IC bị khuyết cột `course_id`. Có thiết lập dynamic từ playlist tài xế để truyền được ID course gốc của IC, hoặc trả NULL. |
+
+## 4. Đồng bộ Tài xế (POST `/api/drivers/sync`)
+Dữ liệu lấy từ bảng `employees` của IC.
+
+| Field y/cầu của VPL | Nguồn dữ liệu bên IC (Bảng `employees`)| Logic Transform (Biến đổi) tại IC |
+| :--- | :--- | :--- |
+| `departmentId` | Bảng `employee_department` | **[CẦN BIẾN ĐỔI]** Lấy từ relation `departments()` (Many-to-Many), trích Department chính và map thành code `"LOCxxx"`. |
+| `code` | `$employee->employee_code` | Map trực tiếp 1-1. |
+| `name` | `$employee->name` | Map trực tiếp 1-1. |
+| `externalId` | `$employee->id` | ID của IC làm tham chiếu gốc. |
+
+*Lưu ý: Để gán Driver vào Course, IC cần query thêm dữ liệu từ ATMTC trước khi đóng gói payload.*
+
+## 5. API Đồng bộ Chi phí Xe (POST `/api/vehicle-monthly-costs/sync`)
+Dữ liệu trộn lẫn giữa IC và hệ thống ITP bên ngoài. Định dạng danh sách theo theo `yearMonth`.
+
+| Field y/cầu của VPL | Nguồn IC cung cấp / lấy từ API | Logic Transform (Biến đổi) tại IC |
+| :--- | :--- | :--- |
+| `vehicleId` / `vehicleExternalId`| ID gốc của xe (IC) | Lấy `$vehicle->id`. |
+| `leaseDepreciation`, `vehicleDepreciation`, `insuranceCost`, `taxCost`, `vehicleLease` | Các bảng `MaintenanceLease`, `InsuranceRate`... | Truy vấn tổng hợp số tiền cố định tương ứng theo xe/tháng. |
+| `fuelEfficiency`, `roadUsageFee` | **Fetch cổng API ITP** | IC làm Proxy, gọi API sang ITP lấy 2 thông số này, ghép vào JSON cho VPL. |
+
+## 6. Khối Chi phí Phòng ban (POST `/api/location-monthly-expenses/sync`)
+IC lấy dữ liệu kế toán từ **PCA**.
+
+| Field y/cầu của VPL | Nguồn IC cung cấp / lấy từ API | Logic Transform (Biến đổi) tại IC |
+| :--- | :--- | :--- |
+| `locationId` / `departmentId` | ID phòng ban IC | Diễn dịch ID sang `"LOC001"` quy định. |
+| `accountItemCode` | Các field báo cáo | **[CẦN BIẾN ĐỔI]** Mapping giữa mã của hệ thống PCA cấp với 20 mã chuẩn (`6150`-`6189`) mà VPL quy định. |
+| `amount` | Báo cáo PCA | Con số thực chi do báo cáo trả về. |
+
+---
+**TỔNG KẾT:**
+Để tích hợp thành công, Izumi Cloud cần phát triển một tiến trình (như Job Data Export hoặc API Resource Class) chuyên biệt làm nhiệm vụ **ETL (Extract, Transform, Load)**. Không trút dữ liệu thô thẳng mà phải "nặn" lại tên, mapping ID sang mảng String và đặc biệt phải cắm chung dữ liệu gọi từ hệ thống thứ 3 (ITP, PCA) vào thành một bộ Payload thống nhất trước khi gọi sang VPL.

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/issue.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/issue.md
@@ -1,0 +1,107 @@
+# Issue #956 — [005] イズミクラウド: IZUMI 連携機能の実装
+
+## Context / Codebase Paths (from pre-questions)
+
+```yaml
+repository: TeckVeho/Izumi_Issue-Requests-Repo
+repo: Izumi_Issue-Requests-Repo
+issue_url: https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/956
+github_project_v2_id: PVT_kwDOCjwUv84Ajq0M
+github_project_title: Izumi_Issue
+frontend_path: .
+backend_path: ./backend
+migrations_path: ./backend/prisma/migrations
+api_docs_path:
+tests_path:
+workspace_root: .
+```
+
+**Note:** `migrations_path` is the conventional Prisma location for this repo; the `migrations` folder may not exist until first migrate. Work for this issue is tracked in **vehicle-pl-system**; paths above are relative to this workspace.
+
+---
+
+## Metadata
+
+| Field | Value |
+|--------|--------|
+| **Title** | [005] イズミクラウド: IZUMI 連携機能の実装 |
+| **State** | OPEN |
+| **URL** | https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/956 |
+| **Created** | 2026-03-25T12:24:23Z |
+| **Updated** | 2026-03-25T12:32:27Z |
+| **Assignees** | tungnt183855 |
+| **Labels** | _(none)_ |
+
+---
+
+## Description (summary)
+
+Implement an **Izumi Cloud → IZUMI** integration client that calls IZUMI sync APIs and sends master and accounting data.
+
+**Goals (high level):**
+
+- Authentication & authorization: JWT via `POST /api/auth/login`, MASTER role, token refresh before 7-day expiry
+- Master sync: users, courses, vehicles, vehicle-monthly-costs, location-monthly-expenses, drivers
+- Transaction sync: `POST /api/import`, `POST /api/income-statement/records/bulk`
+- Aggregate from PCA, ATMTC, ITP and send via the appropriate sync endpoints
+- Department ID alignment, error handling (400/401/403/500), retries/alerts, scheduled batch runs
+
+**Reference docs (from issue body, paths relative to Izumi issue repo):**
+
+- `../docs/external-integration-spec.md`
+- `../docs/external-system-implementation-checklist.md`
+- `../docs/department-id-standard.md`
+
+---
+
+## Implementation checklist
+
+### Auth & setup
+
+- [ ] JWT acquisition and token lifecycle (refresh before expiry)
+- [ ] Integration user with MASTER permission (DX / DX admin)
+
+### Master sync clients
+
+- [ ] `POST /api/users/sync`
+- [ ] `POST /api/courses/sync`
+- [ ] `POST /api/vehicles/sync` (after courses sync)
+- [ ] `POST /api/vehicle-monthly-costs/sync` (include ITP `fuelEfficiency`, `roadUsageFee`)
+- [ ] `POST /api/location-monthly-expenses/sync` (PCA monthly location expenses)
+- [ ] `POST /api/drivers/sync` (after ATMTC linkage)
+
+### Transaction sync
+
+- [ ] `POST /api/import`
+- [ ] `POST /api/income-statement/records/bulk`
+
+### External systems
+
+- [ ] PCA → location-monthly-expenses (20 accounts)
+- [ ] ATMTC → driver/course mapping → drivers & courses sync
+- [ ] ITP → fuel & road usage → vehicle-monthly-costs
+
+### Cross-cutting
+
+- [ ] Department ID consistency
+- [ ] Error handling, retries, alerting
+- [ ] Batch / schedule for master and monthly syncs
+
+---
+
+## Notes / review
+
+- **Project V2:** Issue is on GitHub Project **Izumi_Issue** (`PVT_kwDOCjwUv84Ajq0M`). Use this id when `/breakdown` adds child issues to the same project.
+- **Scope:** Issue text targets **Izumi Cloud engineers** calling **this** system’s (IZUMI) APIs; implementation in **vehicle-pl-system** may mean exposing stable APIs, docs, or shared contracts—confirm with product before coding.
+- **Local workspace:** Uncommitted changes existed at branch creation (e.g. `.gitignore`, lockfiles, `.idea/`, `backend/.env.dev`); nothing was committed for this issue doc.
+
+---
+
+## Full body (GitHub)
+
+<details>
+<summary>Click to expand original issue body</summary>
+
+See GitHub issue URL above for the full Japanese/Vietnamese specification and task lists.
+
+</details>

--- a/docs/issues/Izumi_Issue-Requests-Repo/956/plan.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/956/plan.md
@@ -1,0 +1,94 @@
+# Plan — Issue #956: Izumi Cloud → VPL (vehicle-pl-system) sync
+
+## Mục tiêu
+
+Triển khai **client đồng bộ phía Izumi Cloud (IC)** gọi HTTP API của **VPL** (`vehicle-pl-system` backend), đẩy master + dữ liệu kế toán theo `docs/external-integration-spec.md`, với **ETL** (không đẩy raw DB). Chi tiết field-level: [`ic-sync-field-mapping.md`](ic-sync-field-mapping.md).
+
+## Phạm vi & giả định đã chốt
+
+| Hạng mục | Quyết định |
+|----------|------------|
+| Hướng dữ liệu | **IC → VPL** (Cloud chủ động gọi API VPL). |
+| Code chính | Repo **izumi-cloud** (Laravel): HTTP client, ETL, Artisan command. |
+| Contract API | Repo **vehicle-pl-system** (`backend/`): Express + Prisma; tham chiếu `external-integration-spec.md`. |
+| `departmentId` | Chuỗi **`LOC` + str_pad(`departments.id`, 3, '0', STR_PAD_LEFT)`** (vd. `1` → `LOC001`), khớp `Location.code` trên VPL. |
+| Kích hoạt | **Chỉ khi chạy command** (chưa bắt buộc schedule; có thể bổ sung sau). |
+| Logging | Ghi log theo ngày vào **storage** (pattern Laravel `daily` / channel riêng `vpl-sync`). |
+| Thuật ngữ | **VPL** = `vehicle-pl-system`; không nhầm với hệ **PL** legacy (`BASE_URL_PL` trong IC). |
+
+## Tài liệu tham chiếu (VPL)
+
+- `docs/external-integration-spec.md`
+- `docs/external-system-implementation-checklist.md`
+- `docs/department-id-standard.md`
+- Issue: [`issue.md`](issue.md)
+
+## Kiến trúc triển khai (IC)
+
+1. **HTTP client VPL:** base URL theo môi trường (dev: thường `http://localhost:4000`); header `Authorization: Bearer <JWT>`.
+2. **Auth:** `POST /api/auth/login` — user tích hợp có quyền **MASTER** (và **EDIT_PL** cho import/bulk nếu dùng cùng hoặc user riêng); cache token, refresh trước khi hết hạn (7 ngày).
+3. **ETL layer:** class/service per domain (users, courses, vehicles, drivers, monthly costs, location expenses) — đọc DB IC + (ITP, PCA) → payload đúng spec.
+4. **Entry point:** một hoặc nhiều Artisan command, tham số `--entity=`, `--year-month=`, `--dry-run` (nếu implement).
+
+## Phân phase
+
+### Phase 0 — Chuẩn bị
+
+- [ ] Xác nhận base URL VPL dev/stg/prod (constants hoặc config; secret chỉ `.env`).
+- [ ] Tạo user VPL dùng cho liên kết (MASTER / EDIT_PL theo endpoint).
+- [ ] Rà soát seed **`Location.code`** trên VPL khớp quy tắc `LOC` + pad 3 với `departments.id` IC (~20 đơn vị).
+
+### Phase 1 — Nền tảng (IC)
+
+- [ ] Module client VPL + xử lý lỗi HTTP (400/401/403/500), retry tối thiểu (policy ghi trong code/README issue).
+- [ ] Quản lý JWT (lưu cache tạm, login lại khi 401).
+- [ ] Command shell: ví dụ `vpl:sync` với option tách entity.
+
+### Phase 2 — Master sync (theo thứ tự phụ thuộc)
+
+Thứ tự gợi ý: **users → courses → vehicles → drivers** (vehicles sau courses; drivers có thể cần ATMTC sau).
+
+| API VPL | Nội dung chính (IC) | Ghi chú từ mapping |
+|---------|---------------------|---------------------|
+| `POST /api/users/sync` | `users` | Map Spatie role → `VALID_ROLES` VPL. |
+| `POST /api/courses/sync` | `courses` + `departments` | Tạo `name` (IC không có cột tên đủ); `externalId` = `courses.id`. |
+| `POST /api/vehicles/sync` | `vehicles` + biển số qua `latestNumberPlateHistory` | `courseExternalId` có thể null nếu chưa có quan hệ ổn định. |
+| `POST /api/drivers/sync` | `employees` + department chính (many-to-many) | Có thể cần dữ liệu ATMTC cho gán course (sau). |
+
+### Phase 3 — Chi phí theo tháng
+
+- [ ] `POST /api/vehicle-monthly-costs/sync`: gộp bảng nội bộ (MaintenanceLease, InsuranceRate, …) + **ITP API** cho `fuelEfficiency`, `roadUsageFee`; tham số `yearMonth`.
+- [ ] `POST /api/location-monthly-expenses/sync`: **PCA** → map `accountItemCode` sang 20 mã VPL (`6150`–`6189`).
+
+### Phase 4 — Kế toán (chọn ưu tiên)
+
+- [ ] `POST /api/import` (multipart) **hoặc** `POST /api/income-statement/records/bulk` (JSON) — chốt nguồn dữ liệu trên IC (file vs DB) và user có quyền **EDIT_PL**.
+
+### Phase 5 — Kiểm thử & bàn giao
+
+- [ ] Test trên local: từng entity + một kịch bản end-to-end tối thiểu.
+- [ ] Cập nhật `dev.md` / hướng dẫn chạy command; ghi known limitations (ATMTC, course–vehicle nếu chưa xong).
+
+## Tiêu chí hoàn thành (acceptance)
+
+1. Có thể chạy command trên IC và thấy bản ghi tương ứng trên VPL (DB) cho các entity đã implement, với `departmentId` đúng `LOCxxx`.
+2. Log sync theo ngày trong `storage`, đủ để debug (request id / số bản ghi / lỗi API).
+3. Mapping field thống nhất với [`ic-sync-field-mapping.md`](ic-sync-field-mapping.md) hoặc có mục “deviation” ghi rõ nếu đổi so với bản phân tích.
+
+## Rủi ro & hạng mục còn mở
+
+- **Role IC → VPL:** cần bảng map cụ thể (test với từng role thực tế).
+- **Course `name`:** công thức nối chuỗi cần product duyệt.
+- **Vehicle ↔ course:** nếu thiếu `course_id` trên IC, chấp nhận `courseExternalId` null tạm thời hoặc bổ sung nguồn (playlist/ATMTC).
+- **PCA account code:** bảng map PCA → mã VPL cần BA/ kế toán xác nhận.
+- **Import vs bulk:** chọn một đường trước để giảm phạm vi.
+- **Biển số xe (Vehicle Number):** Do IC lưu lịch sử biển số (`latestNumberPlateHistory`), cần đảm bảo query Eloquent khi lấy ra biển số không bị lỗi N+1 Query (do phải lặp qua 500+ chiếc xe).
+
+## Không nằm trong plan này (trừ khi mở rộng issue)
+
+- Cron/schedule tự động (có thể thêm sau bằng cách gọi cùng service từ `Kernel`).
+- Sửa lớn API VPL (chỉ fix lệch spec nếu phát hiện khi tích hợp).
+
+---
+
+*Cập nhật lần cuối: tạo theo `/plan 956` — đồng bộ với thảo luận issue và `ic-sync-field-mapping.md`.*

--- a/docs/issues/Izumi_Issue-Requests-Repo/967/dev.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/967/dev.md
@@ -1,0 +1,250 @@
+# Dev — Issue #967: VPL Sync Users & Courses
+
+## Tổng quan
+
+Issue này triển khai ETL client trên **Izumi Cloud** (Laravel) để đồng bộ dữ liệu **Users** và **Courses** sang hệ thống **VPL** (`vehicle-pl-system`) thông qua REST API.
+
+Reference:
+- [ic-sync-field-mapping.md](../956/ic-sync-field-mapping.md) — bảng ánh xạ field chi tiết
+- [plan.md](../956/plan.md) — kế hoạch tổng thể Issue #956
+- `docs/external-integration-spec.md` — đặc tả API phía VPL
+
+---
+
+## Cấu trúc file mới
+
+```
+izumi-cloud/
+├── config/
+│   └── vpl.php                              # Config VPL (base URL, auth, retry, log)
+├── app/
+│   ├── Console/Commands/
+│   │   └── VplSyncCommand.php               # Artisan command: vpl:sync
+│   └── Services/Vpl/
+│       ├── VplClient.php                    # HTTP client (JWT, retry, re-auth)
+│       ├── UserSyncService.php              # ETL users (Role mapping Spatie → VPL)
+│       └── CourseSyncService.php            # ETL courses (LOC padding, name gen)
+```
+
+File sửa:
+- `config/logging.php` — thêm channel `vpl-sync` (daily, 30 ngày)
+- `.env.example` — thêm biến `VPL_*`
+
+---
+
+## Cài đặt
+
+### 1. Cập nhật `.env`
+
+Thêm các biến sau vào file `.env`:
+
+```dotenv
+# --- VPL Sync ---
+VPL_BASE_URL=http://localhost:4000
+VPL_AUTH_IDENTIFIER=admin@example.com   # Email hoặc User ID trên VPL
+VPL_AUTH_PASSWORD=password
+VPL_TOKEN_TTL=604800
+VPL_RETRY_TIMES=3
+VPL_RETRY_SLEEP_MS=500
+VPL_LOG_CHANNEL=vpl-sync
+```
+
+> **Lưu ý:**
+> - `VPL_AUTH_IDENTIFIER` chấp nhận cả **email** lẫn **User ID** — hệ thống tự nhận diện.
+> - User VPL cần có quyền **MASTER** (role `DX` hoặc `DX管理者`).
+> - Lần chạy đầu tiên trên local: dùng tài khoản seed `admin@example.com` / `password` (từ `npx prisma db seed`).
+
+### 2. Clear config cache
+
+```bash
+cd izumi-cloud
+php artisan config:clear
+```
+
+---
+
+## Sử dụng
+
+### Sync tất cả (users → courses theo thứ tự)
+
+```bash
+php artisan vpl:sync
+```
+
+### Sync riêng từng entity
+
+```bash
+php artisan vpl:sync --entity=users
+php artisan vpl:sync --entity=courses
+```
+
+### Dry-run (chỉ tạo payload, không gửi API)
+
+```bash
+php artisan vpl:sync --dry-run
+php artisan vpl:sync --entity=users --dry-run
+```
+
+### Verbose output (hiển thị chi tiết skipped records)
+
+```bash
+php artisan vpl:sync -v
+php artisan vpl:sync --entity=users -v --dry-run
+```
+
+---
+
+## Kiến trúc
+
+### Data Flow
+
+```
+IC Database (MySQL)
+    │
+    ├── users table + Spatie roles
+    │   └── UserSyncService.buildPayload()
+    │       └── mapRole() → VALID_ROLES mapping
+    │
+    ├── courses table + departments table
+    │   └── CourseSyncService.buildPayload()
+    │       ├── toDepartmentCode() → "LOC001"
+    │       └── generateCourseName() → nối course_type/address
+    │
+    └──▶ VplClient.post('/api/users/sync', payload)
+         VplClient.post('/api/courses/sync', payload)
+             │
+             ├── JWT login (cached, auto-refresh)
+             ├── Retry logic (exponential back-off)
+             └── 401 → re-auth → retry
+```
+
+### Role Mapping (Users)
+
+| IC Role (Spatie `name`) | VPL Role |
+|---|---|
+| `crew` | `CREW` |
+| `clerks` | `事務員` |
+| `tl` | `TL` |
+| `department_office_staff` | `事業部` |
+| `personnel_labor` | `人事労務` |
+| `general_affair` | `総務広報` |
+| `accounting` | `経理財務` |
+| `quality_control` | `品質管理` |
+| `sales` | `営業` |
+| `site_manager` | `現場MG` |
+| `hq_manager` | `本社MG` |
+| `department_manager` | `部長` |
+| `executive_officer` | `執行役員` |
+| `director` | `取締役` |
+| `dx_user` | `DX` |
+| `dx_manager` | `DX管理者` |
+| `am_sm` | `現場MG` |
+
+> User không có role khớp sẽ bị **skip** (không gửi sang VPL, tránh crash batch).
+
+### Department ID Conversion (Courses)
+
+```
+departments.id = 1  → "LOC001"
+departments.id = 22 → "LOC022"
+```
+
+Công thức: `'LOC' . str_pad($id, 3, '0', STR_PAD_LEFT)`
+
+### Course Name Generation
+
+IC không có cột `name` trên bảng `courses`. Tên được ghép từ:
+
+1. `course_type` + `bin_type` + `address` (nếu có) → `"ＣＶＳ - 東京都港区"`
+2. Fallback: `department.name` + `course_code` → `"横浜第一 001-001"`
+
+---
+
+## Logging
+
+Log file: `storage/logs/vpl-sync/vpl-sync-YYYY-MM-DD.log`
+
+Các log message chính:
+- `[VplClient] VPL login successful`
+- `[UserSync] Sending users/sync` (count, skipped)
+- `[CourseSync] Sending courses/sync`
+- `[VplSync] --- VPL Sync Start/End ---`
+- Error/Warning khi retry hoặc skip records
+
+---
+
+## Xử lý lỗi
+
+| HTTP Status | Hành vi |
+|---|---|
+| `200` | Thành công, log response |
+| `400` | Client error → log chi tiết, **không retry** |
+| `401` | Token expired → xóa cache, login lại, retry 1 lần |
+| `403` | Permission denied → log error, dừng entity đó |
+| `5xx` | Server error → retry tối đa 3 lần (exponential back-off) |
+| Network error | Retry tối đa 3 lần |
+
+---
+
+## Kiểm thử
+
+### Dry-run test (không cần VPL chạy)
+
+```bash
+php artisan vpl:sync --dry-run -v
+```
+
+Kiểm tra output có:
+- Số lượng users/courses sẽ sync
+- Danh sách skipped records (với `-v`)
+- Log file trong `storage/logs/vpl-sync/`
+
+### Integration test (cần VPL chạy trên localhost:4000)
+
+```bash
+# 1. Start VPL backend
+cd ../backend && npm run dev
+
+# 2. Chạy sync
+cd ../izumi-cloud
+php artisan vpl:sync --entity=users
+php artisan vpl:sync --entity=courses
+
+# 3. Kiểm tra kết quả trên VPL
+# GET http://localhost:4000/api/users → sẽ thấy users mới
+# GET http://localhost:4000/api/courses → sẽ thấy courses mới
+```
+
+---
+
+## Timestamp Sync
+
+- `createdAt` và `updatedAt` từ IC được đồng bộ sang VPL (ISO 8601).
+- VPL sẽ dùng timestamp gốc từ IC thay vì auto-generate.
+- Cột `deletedAt` đã được thêm vào VPL schema (nullable) — **chưa sync**, dành cho tương lai.
+
+---
+
+## Bugfixes (phát hiện khi integration test)
+
+| Bug | Nguyên nhân | Sửa |
+|-----|------------|-----|
+| IC báo "557 synced" nhưng VPL chỉ có 3 user | IC có 581 user nhưng chỉ 9 email duy nhất → VPL `@unique` email constraint reject | `UserSyncService` tạo dummy email `user_{id}@izumi-dummy.local` cho email trùng |
+| `UserSyncService` báo thành công khi VPL trả 500 | Không kiểm tra `_error` trong response array | Thêm check `_error` → throw `RuntimeException` |
+| `CourseSyncService` tương tự | `courses/sync` không check `_error` | `CourseSyncService::sync()` cũng check `_error` + dùng `synced` từ response nếu có |
+| cURL timeout 30s khi sync 500+ users | bcrypt hash 500+ passwords > 30s | Tăng timeout lên 120s |
+| Login VPL thất bại khi dùng email | `VplClient` gửi email dưới key `userId` → VPL tìm `externalId` | Tự nhận diện `@` → gửi key `email` |
+| Tên biến `VPL_AUTH_USER_ID` gây nhầm lẫn | Giá trị có thể là email | Đổi thành `VPL_AUTH_IDENTIFIER` (backward-compatible) |
+
+---
+
+## Known Limitations
+
+- **ATMTC data:** Chưa tích hợp — courses không có driver linkage từ ATMTC.
+- **Course name:** Logic nối chuỗi có thể cần product duyệt; điều chỉnh trong `CourseSyncService::generateCourseName()`.
+- **Role `am_sm`:** Hiện map sang `現場MG` (closest match). Cần xác nhận với BA nếu cần role riêng trên VPL.
+- **deletedAt:** Cột đã có trên VPL schema, nhưng chưa được sync từ IC.
+- **Schedule:** Chưa đăng ký cron. Khi cần, thêm vào `app/Console/Kernel.php`:
+  ```php
+  $schedule->command('vpl:sync')->dailyAt('02:00');
+  ```

--- a/docs/issues/Izumi_Issue-Requests-Repo/967/issue.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/967/issue.md
@@ -1,0 +1,83 @@
+# Issue #967 — [BE] VPL同期: users・courses / Đồng bộ users & courses
+
+## Context / Codebase Paths (from pre-questions)
+
+**Issue lookup:** `#967` は **カレント git リポジトリ**（`TeckVeho/vehicle-pl-system`）には存在しません。トラッキングは **`TeckVeho/Izumi_Issue-Requests-Repo`** の #967 です（親: #956）。
+
+```yaml
+repository: TeckVeho/Izumi_Issue-Requests-Repo
+repo: Izumi_Issue-Requests-Repo
+issue_url: https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/967
+github_project_v2_id: PVT_kwDOCjwUv84Ajq0M
+github_project_title: Izumi_Issue
+frontend_path: .
+backend_path: ./izumi-cloud
+migrations_path: ./izumi-cloud/database/migrations
+api_docs_path:
+tests_path: ./izumi-cloud/tests
+workspace_root: .
+```
+
+**Note:** 実装の主対象は **`./izumi-cloud`**（Laravel / PHPUnit）。`frontend_path: .` はワークスペース直下の Next.js（VPL）；本 issue の記述では主に IC 側バックエンドが対象。フィールドマッピングは親ドキュメント `docs/issues/Izumi_Issue-Requests-Repo/956/ic-sync-field-mapping.md` を参照。
+
+---
+
+## Metadata
+
+| Field | Value |
+|--------|--------|
+| **Title** | [BE] VPL同期: users・courses / Đồng bộ users & courses |
+| **State** | OPEN |
+| **URL** | https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/967 |
+| **Created** | 2026-03-27T03:39:42Z |
+| **Updated** | 2026-03-27T03:50:24Z |
+| **Assignees** | tungnt183855 |
+| **Labels** | backend, enhancement, Child issue |
+
+---
+
+## Description (summary)
+
+**Parent:** #956
+
+Implement ETL and callers for **`POST /api/users/sync`** and **`POST /api/courses/sync`** (Izumi Cloud → VPL).
+
+- **`departmentId`:** `LOC` + zero-padded 3-digit `departments.id`
+- **Course `name`:** No direct IC column — generate per plan / `ic-sync-field-mapping.md`
+- **`externalId`:** IC `id`
+- **Roles:** Map Spatie role → VPL `VALID_ROLES`
+
+**Repository (implementation):** **izumi-cloud** (in this workspace: `./izumi-cloud`)
+
+**Dependency:** Child issue “VPL 基盤”（HTTP client / JWT）マージ後に結合テスト可能
+
+---
+
+## Acceptance criteria (from issue body)
+
+- [x] 実装完了 / Hoàn thành triển khai
+- [x] ユニットテスト作成・合格 / Unit test đạt（サービス／トランスフォーマ）
+- [x] プロジェクト規約に準拠 / Tuân thủ quy ước
+- [x] 既存機能への破壊的変更なし / Không breaking change
+
+---
+
+## Implementation checklist
+
+- [x] `ic-sync-field-mapping.md` §1–2 に沿った users / courses のマッピング
+- [x] `POST /api/users/sync` 呼び出しと ETL
+- [x] `POST /api/courses/sync` 呼び出しと ETL
+- [x] `departmentId` = `LOC` + 3 桁ゼロ埋め `departments.id`
+- [x] コース `name` の生成ロジック（plan / mapping doc 準拠）
+- [x] `externalId` ← IC `id`
+- [x] Spatie role → VPL `VALID_ROLES` マッピング
+- [x] PHPUnit（サービス／トランスフォーマ）
+- [ ] 基盤 issue（JWT・HTTP クライアント）との結合確認（マージ後）
+
+---
+
+## Notes / review
+
+- **Paths:** `/plan`, `/breakdown`, `/dev` は上記 YAML と本ディレクトリ `docs/issues/Izumi_Issue-Requests-Repo/967/` を参照すること。
+- **Project V2:** `/breakdown` で子 issue をプロジェクトに載せる際は `github_project_v2_id` を使用（**Izumi_Issue**）。
+- **Role mapping fallback:** Đảm bảo class Mapping xử lý tốt trường hợp User ở IC chưa có Role hoặc có Role không nằm trong tập `VALID_ROLES` của VPL (cần có fallback default logic hoặc bỏ qua user đó để tránh văng Exception làm dừng toàn bộ tiến trình batch update).

--- a/docs/issues/Izumi_Issue-Requests-Repo/967/pr.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/967/pr.md
@@ -1,0 +1,42 @@
+# PR: VPL sync users & courses (Izumi Cloud ↔ vehicle-pl-system)
+
+Closes TeckVeho/Izumi_Issue-Requests-Repo#967
+
+## Summary
+
+Implements and supports **Izumi Cloud → VPL** master sync for **users** and **courses** (issue #967, parent #956): resilient API behavior on the VPL backend, larger JSON payloads, persisted user timestamps, and local issue documentation.
+
+### vehicle-pl-system (this repo)
+
+1. **`express.json({ limit: "5mb" })`** (`backend/src/index.ts`) — avoid **413** on bulk `POST /api/users/sync` and `POST /api/courses/sync`.
+2. **`POST /api/users/sync`** (`backend/src/routes/users.ts`) — accept **`createdAt` / `updatedAt`** from the payload on create and update (IC → VPL timestamp alignment).
+3. **Prisma `User`** (`backend/prisma/schema.prisma`) — optional **`deletedAt`** for future IC soft-delete; datasource aligned for deployment (**MySQL** in current schema).
+4. **`POST /api/courses/sync`** (`backend/src/routes/courses.ts`) — upsert: resolve existing row by **`externalId`**, else by **`(locationId, code)`**, to prevent **`P2002`** / HTTP 500 when IC resends the same location+code with a new external id.
+
+### Documentation (tracked under `docs/issues/`)
+
+- **#956:** `issue.md`, `plan.md`, `ic-sync-field-mapping.md`, breakdown summaries and child issue bodies.
+- **#967:** `issue.md`, `dev.md` (Artisan usage, env, mapping notes).
+
+### Not in this PR branch (local / optional follow-up)
+
+- **`izumi-cloud/`** Laravel services (`VplClient`, `UserSyncService`, `CourseSyncService`, `vpl:sync`) may exist in the workspace but are **untracked** unless you add them in a separate commit.
+- **`docs/issues/.../967/evidence/test-results.json`** — not present; see Evidence below.
+
+## Evidence
+
+⚠️ **No test results file** — `docs/issues/Izumi_Issue-Requests-Repo/967/evidence/test-results.json` was not found. Run tests locally before merge if required by team policy.
+
+### Manual / suggested checks
+
+```bash
+# Izumi Cloud — VPL unit tests (when izumi-cloud is in the repo)
+cd izumi-cloud && ./vendor/bin/phpunit tests/Unit/Vpl/
+
+# VPL backend — typecheck (from repo root)
+cd backend && npx tsc --noEmit
+```
+
+## Screenshots
+
+None (API and sync work; no UI change required for this issue).


### PR DESCRIPTION
# PR: VPL sync users & courses (Izumi Cloud ↔ vehicle-pl-system)

Closes TeckVeho/Izumi_Issue-Requests-Repo#967
Closes TeckVeho/Izumi_Issue-Requests-Repo#966

## Summary

Implements and supports **Izumi Cloud → VPL** master sync for **users** and **courses** (issue #967, parent #956): resilient API behavior on the VPL backend, larger JSON payloads, persisted user timestamps, and local issue documentation.

### vehicle-pl-system (this repo)

1. **`express.json({ limit: "5mb" })`** (`backend/src/index.ts`) — avoid **413** on bulk `POST /api/users/sync` and `POST /api/courses/sync`.
2. **`POST /api/users/sync`** (`backend/src/routes/users.ts`) — accept **`createdAt` / `updatedAt`** from the payload on create and update (IC → VPL timestamp alignment).
3. **Prisma `User`** (`backend/prisma/schema.prisma`) — optional **`deletedAt`** for future IC soft-delete; datasource aligned for deployment (**MySQL** in current schema).
4. **`POST /api/courses/sync`** (`backend/src/routes/courses.ts`) — upsert: resolve existing row by **`externalId`**, else by **`(locationId, code)`**, to prevent **`P2002`** / HTTP 500 when IC resends the same location+code with a new external id.

### Documentation (tracked under `docs/issues/`)

- **#956:** `issue.md`, `plan.md`, `ic-sync-field-mapping.md`, breakdown summaries and child issue bodies.
- **#967:** `issue.md`, `dev.md` (Artisan usage, env, mapping notes).

### Not in this PR branch (local / optional follow-up)

- **`izumi-cloud/`** Laravel services (`VplClient`, `UserSyncService`, `CourseSyncService`, `vpl:sync`) may exist in the workspace but are **untracked** unless you add them in a separate commit.
- **`docs/issues/.../967/evidence/test-results.json`** — not present; see Evidence below.

## Evidence

⚠️ **No test results file** — `docs/issues/Izumi_Issue-Requests-Repo/967/evidence/test-results.json` was not found. Run tests locally before merge if required by team policy.

### Manual / suggested checks

```bash
# Izumi Cloud — VPL unit tests (when izumi-cloud is in the repo)
cd izumi-cloud && ./vendor/bin/phpunit tests/Unit/Vpl/

# VPL backend — typecheck (from repo root)
cd backend && npx tsc --noEmit
```

## Screenshots

None (API and sync work; no UI change required for this issue).
