### PR TITLE
Update logic user sync relate to password

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -7,6 +7,18 @@ function isBcryptHash(value: string): boolean {
   return /^\$2[aby]\$\d{2}\$.{53}$/.test(value);
 }
 
+/**
+ * Normalize PHP $2y$ bcrypt hashes to $2b$ for Node.js compatibility.
+ * PHP Hash::make() produces $2y$ hashes which are algorithmically identical
+ * to $2b$ but the Node.js bcrypt library cannot verify $2y$ hashes.
+ */
+function normalizeBcryptHash(hash: string): string {
+  if (hash.startsWith("$2y$")) {
+    return "$2b$" + hash.slice(4);
+  }
+  return hash;
+}
+
 // 有効な権限一覧（外部システム同期用）
 export const VALID_ROLES = [
   "CREW",
@@ -101,7 +113,7 @@ usersRouter.post("/", async (req: Request, res: Response) => {
     }
 
     const passwordHash = password
-      ? (isBcryptHash(String(password)) ? String(password) : await bcrypt.hash(String(password), 10))
+      ? (isBcryptHash(String(password)) ? normalizeBcryptHash(String(password)) : await bcrypt.hash(String(password), 10))
       : await bcrypt.hash("changeme", 10);
 
     const data = {
@@ -212,7 +224,7 @@ usersRouter.post("/sync", async (req: Request, res: Response) => {
       if (!VALID_ROLES.includes(role)) continue;
 
       const passwordHash = password
-        ? (isBcryptHash(String(password)) ? String(password) : await bcrypt.hash(String(password), 10))
+        ? (isBcryptHash(String(password)) ? normalizeBcryptHash(String(password)) : await bcrypt.hash(String(password), 10))
         : await bcrypt.hash("changeme", 10);
 
       const timestamps: Record<string, Date> = {};


### PR DESCRIPTION
# Description
- fix: normalize PHP "$2y$" bcrypt hashes to "$2b$" for Node.js compatibility in user sync
- Issue [#969](https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/969)