### PR TITLE
feat(backend): Vitest + sync contract tests (Izumi #955)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,9 +26,12 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^1.4.11",
         "@types/node": "^20",
+        "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
+        "supertest": "^7.0.0",
         "tsx": "^4.19.2",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -473,6 +476,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
@@ -541,6 +574,356 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/bcrypt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -560,6 +943,17 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/connect": {
@@ -582,6 +976,13 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -592,12 +993,27 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -635,6 +1051,13 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -717,6 +1140,145 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -749,6 +1311,30 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bcrypt": {
@@ -821,6 +1407,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -863,6 +1459,33 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/codepage": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
@@ -870,6 +1493,29 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concat-stream": {
@@ -936,6 +1582,13 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -980,6 +1633,26 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -997,6 +1670,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dunder-proto": {
@@ -1055,6 +1739,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1062,6 +1753,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1115,6 +1822,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1122,6 +1839,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1170,6 +1897,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -1186,6 +1938,41 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -1313,6 +2100,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1376,6 +2179,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
@@ -1468,6 +2278,23 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1584,6 +2411,25 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1646,6 +2492,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1661,6 +2517,73 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prisma": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
@@ -1668,6 +2591,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -1768,6 +2692,51 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -1931,6 +2900,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ssf": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
@@ -1943,6 +2929,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1951,6 +2944,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -1975,6 +2975,164 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1990,6 +3148,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2077,6 +3236,244 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wmf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
@@ -2094,6 +3491,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/xlsx": {
       "version": "0.18.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,9 @@
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
@@ -32,9 +34,12 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^1.4.11",
     "@types/node": "^20",
+    "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",
+    "supertest": "^7.0.0",
     "tsx": "^4.19.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.0.0"
   },
   "prisma": {
     "seed": "node prisma/seed.cjs"

--- a/backend/src/__tests__/sync-routes.contract.test.ts
+++ b/backend/src/__tests__/sync-routes.contract.test.ts
@@ -1,0 +1,527 @@
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "dev-secret-change-in-production";
+
+function signToken(role: string, userId: string) {
+  return jwt.sign(
+    { userId, email: `${userId}@test.local`, role },
+    JWT_SECRET,
+    { expiresIn: "7d" }
+  );
+}
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    user: { findUnique: vi.fn() },
+    location: { findMany: vi.fn(), findUnique: vi.fn() },
+    vehicle: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+      update: vi.fn(),
+    },
+    course: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      aggregate: vi.fn(),
+    },
+    driver: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    accountItem: { findMany: vi.fn() },
+    driverMonthlyAmount: { upsert: vi.fn() },
+    dailyDriverAssignment: { findMany: vi.fn(), deleteMany: vi.fn(), createMany: vi.fn() },
+    dailyOperatingRecord: { upsert: vi.fn() },
+    vehicleMonthlyCost: { findUnique: vi.fn(), upsert: vi.fn() },
+    locationMonthlyExpense: { findMany: vi.fn() },
+    monthlyRecord: { findUnique: vi.fn(), upsert: vi.fn() },
+    dataSyncLog: { create: vi.fn() },
+    $executeRawUnsafe: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/prisma.js", () => ({
+  prisma: prismaMock,
+}));
+
+// Mock allocation modules called by routes after sync
+vi.mock("../lib/driver-allocation.js", () => ({
+  runDriverAllocation: vi.fn().mockResolvedValue({ vehiclesUpdated: 0, recordsUpdated: 0 }),
+}));
+vi.mock("../lib/salary-run-count-allocation.js", () => ({
+  runSalaryRunCountAllocation: vi.fn().mockResolvedValue({ vehiclesUpdated: 0, recordsUpdated: 0 }),
+}));
+vi.mock("../lib/location-expense-allocation.js", () => ({
+  runLocationExpenseAllocation: vi.fn().mockResolvedValue({ vehiclesUpdated: 0, recordsUpdated: 0 }),
+}));
+
+import { createApp } from "../app.js";
+
+const app = createApp();
+
+function masterToken() {
+  return signToken("DX", "u1");
+}
+
+describe("sync route contracts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "u1",
+      email: "u1@test.local",
+      name: "Test",
+      role: "DX",
+    });
+    prismaMock.location.findMany.mockResolvedValue([]);
+    prismaMock.location.findUnique.mockResolvedValue(null);
+    prismaMock.dataSyncLog.create.mockResolvedValue({} as never);
+  });
+
+  // ── vehicles/sync ─────────────────────────────────
+
+  describe("POST /api/vehicles/sync", () => {
+    it("returns 401 without auth", async () => {
+      const res = await request(app).post("/api/vehicles/sync").send({ vehicles: [] });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when role is not MASTER", async () => {
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: "u2",
+        email: "u2@test.local",
+        name: "Crew",
+        role: "CREW",
+      });
+      const token = signToken("CREW", "u2");
+      const res = await request(app)
+        .post("/api/vehicles/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ vehicles: [] });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 400 when vehicles is not an array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/vehicles/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ vehicles: "nope" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "vehicles array is required" });
+    });
+
+    it("returns 200 with counts for empty vehicles array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/vehicles/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ vehicles: [] });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        synced: 0,
+        skippedCount: 0,
+        results: [],
+      });
+      expect(prismaMock.location.findMany).toHaveBeenCalled();
+    });
+
+    it("accepts Authorization: Bearer token (same as cookie)", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/vehicles/sync")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ vehicles: [] });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ synced: 0, skippedCount: 0, results: [] });
+    });
+  });
+
+  // ── courses/sync ──────────────────────────────────
+
+  describe("POST /api/courses/sync", () => {
+    it("returns 400 when courses payload is not an array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/courses/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ courses: {} });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "courses array is required" });
+    });
+
+    it("returns 200 with synced count for empty courses array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/courses/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ courses: [] });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ synced: 0, results: [] });
+    });
+  });
+
+  // ── driver-assignments/sync ───────────────────────
+
+  describe("POST /api/driver-assignments/sync", () => {
+    it("returns 400 when yearMonth is missing", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-assignments/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ records: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: "yearMonth and records array are required",
+      });
+    });
+
+    it("returns 400 when records is missing", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-assignments/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: "yearMonth and records array are required",
+      });
+    });
+
+    it("returns 400 when records is not an array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-assignments/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", records: "bad" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: "yearMonth and records array are required",
+      });
+    });
+
+    it("returns 400 when yearMonth is not YYYY-MM", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-assignments/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "202603", records: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "yearMonth must be YYYY-MM format" });
+    });
+  });
+
+  // ── drivers/sync ──────────────────────────────────
+
+  describe("POST /api/drivers/sync", () => {
+    it("returns 400 when drivers is not an array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/drivers/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ drivers: "not-array" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "drivers array is required" });
+    });
+
+    it("returns 200 with empty results for empty drivers array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/drivers/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ drivers: [] });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        success: true,
+        results: [],
+      });
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await request(app)
+        .post("/api/drivers/sync")
+        .send({ drivers: [] });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when role is not MASTER", async () => {
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: "u3",
+        email: "u3@test.local",
+        name: "Crew",
+        role: "CREW",
+      });
+      const token = signToken("CREW", "u3");
+      const res = await request(app)
+        .post("/api/drivers/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ drivers: [] });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ── driver-monthly-amounts/sync ───────────────────
+
+  describe("POST /api/driver-monthly-amounts/sync", () => {
+    it("returns 400 when yearMonth is missing", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-monthly-amounts/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ records: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: "yearMonth and records array are required",
+      });
+    });
+
+    it("returns 400 when records is missing", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-monthly-amounts/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: "yearMonth and records array are required",
+      });
+    });
+
+    it("returns 400 when records is not an array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-monthly-amounts/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", records: "bad" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: "yearMonth and records array are required",
+      });
+    });
+
+    it("returns 400 when yearMonth is not YYYY-MM format", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-monthly-amounts/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "March2026", records: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "yearMonth must be YYYY-MM format" });
+    });
+
+    it("returns 200 for empty records with valid yearMonth", async () => {
+      prismaMock.accountItem.findMany.mockResolvedValue([]);
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/driver-monthly-amounts/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", records: [] });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        success: true,
+        upserted: 0,
+      });
+      expect(res.body).toHaveProperty("allocation");
+      expect(res.body).toHaveProperty("salaryAllocation");
+    });
+  });
+
+  // ── daily-operating/sync ──────────────────────────
+
+  describe("POST /api/daily-operating/sync", () => {
+    it("returns 400 when yearMonth is missing", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/daily-operating/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ records: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: "yearMonth and records array are required",
+      });
+    });
+
+    it("returns 400 when records is not an array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/daily-operating/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", records: "invalid" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: "yearMonth and records array are required",
+      });
+    });
+
+    it("returns 400 when yearMonth is not YYYY-MM format", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/daily-operating/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "March", records: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "yearMonth must be YYYY-MM format" });
+    });
+
+    it("returns 200 for valid empty records", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/daily-operating/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", records: [] });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        success: true,
+        upserted: 0,
+      });
+      expect(res.body).toHaveProperty("salaryAllocation");
+    });
+  });
+
+  // ── location-monthly-expenses/sync ────────────────
+
+  describe("POST /api/location-monthly-expenses/sync", () => {
+    it("returns 400 when yearMonth is missing", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/location-monthly-expenses/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ expenses: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "yearMonth (YYYY-MM) is required" });
+    });
+
+    it("returns 400 when yearMonth is invalid format", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/location-monthly-expenses/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "202603", expenses: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "yearMonth (YYYY-MM) is required" });
+    });
+
+    it("returns 400 when expenses is not an array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/location-monthly-expenses/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", expenses: "bad" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "expenses array is required" });
+    });
+
+    it("returns 200 for valid empty expenses", async () => {
+      prismaMock.accountItem.findMany.mockResolvedValue([]);
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/location-monthly-expenses/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", expenses: [] });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        success: true,
+        upserted: 0,
+      });
+      expect(res.body).toHaveProperty("allocation");
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await request(app)
+        .post("/api/location-monthly-expenses/sync")
+        .send({ yearMonth: "2026-03", expenses: [] });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when role is not MASTER", async () => {
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: "u4",
+        email: "u4@test.local",
+        name: "Viewer",
+        role: "CREW",
+      });
+      const token = signToken("CREW", "u4");
+      const res = await request(app)
+        .post("/api/location-monthly-expenses/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", expenses: [] });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ── vehicle-monthly-costs/sync ────────────────────
+
+  describe("POST /api/vehicle-monthly-costs/sync", () => {
+    it("returns 400 when yearMonth is missing", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/vehicle-monthly-costs/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ costs: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "yearMonth (YYYY-MM) is required" });
+    });
+
+    it("returns 400 when yearMonth is invalid format", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/vehicle-monthly-costs/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "bad", costs: [] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "yearMonth (YYYY-MM) is required" });
+    });
+
+    it("returns 400 when costs is not an array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/vehicle-monthly-costs/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", costs: "nope" });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "costs array is required" });
+    });
+
+    it("returns 200 for valid empty costs array", async () => {
+      const token = masterToken();
+      const res = await request(app)
+        .post("/api/vehicle-monthly-costs/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", costs: [] });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        synced: 0,
+        yearMonth: "2026-03",
+        results: [],
+      });
+    });
+
+    it("returns 401 without auth", async () => {
+      const res = await request(app)
+        .post("/api/vehicle-monthly-costs/sync")
+        .send({ yearMonth: "2026-03", costs: [] });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when role is not MASTER", async () => {
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: "u5",
+        email: "u5@test.local",
+        name: "Viewer",
+        role: "CREW",
+      });
+      const token = signToken("CREW", "u5");
+      const res = await request(app)
+        .post("/api/vehicle-monthly-costs/sync")
+        .set("Cookie", `auth-token=${token}`)
+        .send({ yearMonth: "2026-03", costs: [] });
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,21 @@
+import express from "express";
+import cors from "cors";
+import cookieParser from "cookie-parser";
+import { apiRouter } from "./routes/index.js";
+
+export function createApp(): express.Application {
+  const app = express();
+  const CORS_ORIGIN = process.env.CORS_ORIGIN ?? "http://localhost:3000";
+
+  app.use(
+    cors({
+      origin: CORS_ORIGIN,
+      credentials: true,
+    })
+  );
+  app.use(cookieParser());
+  app.use(express.json({ limit: "5mb" }));
+
+  app.use("/api", apiRouter);
+  return app;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,22 +1,7 @@
-import express from "express";
-import cors from "cors";
-import cookieParser from "cookie-parser";
-import { apiRouter } from "./routes/index.js";
+import { createApp } from "./app.js";
 
-const app = express();
+const app = createApp();
 const PORT = process.env.PORT ?? 4000;
-const CORS_ORIGIN = process.env.CORS_ORIGIN ?? "http://localhost:3000";
-
-app.use(
-  cors({
-    origin: CORS_ORIGIN,
-    credentials: true,
-  })
-);
-app.use(cookieParser());
-app.use(express.json({ limit: "5mb" }));
-
-app.use("/api", apiRouter);
 
 app.listen(PORT, () => {
   console.log(`Backend server running at http://localhost:${PORT}`);

--- a/backend/src/lib/account-item-filter.test.ts
+++ b/backend/src/lib/account-item-filter.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { accountItemEffectiveWhere } from "./account-item-filter.js";
+
+describe("accountItemEffectiveWhere", () => {
+  it("returns OR of four effective-range patterns for a year-month string", () => {
+    const w = accountItemEffectiveWhere("2026-03");
+    expect(w).toEqual({
+      OR: [
+        { effectiveFrom: null, effectiveTo: null },
+        { effectiveFrom: null, effectiveTo: { gte: "2026-03" } },
+        { effectiveFrom: { lte: "2026-03" }, effectiveTo: null },
+        {
+          effectiveFrom: { lte: "2026-03" },
+          effectiveTo: { gte: "2026-03" },
+        },
+      ],
+    });
+  });
+});

--- a/backend/src/lib/calc.test.ts
+++ b/backend/src/lib/calc.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  calcNetRevenue,
+  calcSalesRatio,
+  calcTotalExpense,
+  getCategoryLabel,
+  isExpenseItem,
+  isRevenueItem,
+  isSubtotalItem,
+  REVENUE_CATEGORY,
+} from "./calc.js";
+
+describe("calcNetRevenue / calcTotalExpense", () => {
+  it("sums only ids present in the set", () => {
+    const m = new Map([
+      ["a", 100],
+      ["b", 50],
+      ["c", 25],
+    ]);
+    expect(calcNetRevenue(m, new Set(["a", "c"]))).toBe(125);
+    expect(calcTotalExpense(m, new Set(["b"]))).toBe(50);
+  });
+
+  it("returns 0 for empty map", () => {
+    expect(calcNetRevenue(new Map(), new Set(["x"]))).toBe(0);
+  });
+});
+
+describe("calcSalesRatio", () => {
+  it("returns 0 when net revenue is 0", () => {
+    expect(calcSalesRatio(100, 0)).toBe(0);
+  });
+
+  it("returns percentage of net revenue", () => {
+    expect(calcSalesRatio(25, 100)).toBe(25);
+  });
+});
+
+describe("category helpers", () => {
+  it("detects revenue and expense items", () => {
+    expect(isRevenueItem({ category: REVENUE_CATEGORY })).toBe(true);
+    expect(isExpenseItem({ category: "expense" })).toBe(true);
+  });
+
+  it("detects subtotal rows", () => {
+    expect(isSubtotalItem({ isSubtotal: true })).toBe(true);
+  });
+
+  it("getCategoryLabel returns Japanese labels", () => {
+    expect(getCategoryLabel("revenue")).toBe("売上");
+    expect(getCategoryLabel("expense")).toBe("原価");
+    expect(getCategoryLabel("unknown")).toBe("");
+  });
+});

--- a/backend/src/lib/driver-allocation.test.ts
+++ b/backend/src/lib/driver-allocation.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  accountItem: { findMany: vi.fn() },
+  vehicle: { findMany: vi.fn() },
+  dailyDriverAssignment: { findMany: vi.fn() },
+  driverMonthlyAmount: { findMany: vi.fn() },
+  monthlyRecord: { findUnique: vi.fn(), upsert: vi.fn() },
+}));
+
+vi.mock("./prisma.js", () => ({
+  prisma: prismaMock,
+}));
+
+import { runDriverAllocation } from "./driver-allocation.js";
+
+describe("runDriverAllocation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.monthlyRecord.findUnique.mockResolvedValue(null);
+    prismaMock.monthlyRecord.upsert.mockResolvedValue({} as never);
+  });
+
+  it("returns zeros when no driver-related account items exist", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([]);
+    const result = await runDriverAllocation("2026-03");
+    expect(result).toEqual({ vehiclesUpdated: 0, recordsUpdated: 0 });
+    expect(prismaMock.vehicle.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns zeros when account items exist but no vehicles", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "ai1" }]);
+    prismaMock.vehicle.findMany.mockResolvedValue([]);
+    const result = await runDriverAllocation("2026-03");
+    expect(result).toEqual({ vehiclesUpdated: 0, recordsUpdated: 0 });
+    expect(prismaMock.dailyDriverAssignment.findMany).not.toHaveBeenCalled();
+  });
+
+  it("skips upserts when driver amounts are all zero", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "ai1" }]);
+    prismaMock.vehicle.findMany.mockResolvedValue([{ id: "v1" }]);
+    prismaMock.dailyDriverAssignment.findMany.mockResolvedValue([
+      { driverId: "d1", vehicleId: "v1", date: "2026-03-01" },
+    ]);
+    prismaMock.driverMonthlyAmount.findMany.mockResolvedValue([
+      { driverId: "d1", accountItemId: "ai1", amount: 0 },
+    ]);
+    const result = await runDriverAllocation("2026-03");
+    expect(result).toEqual({ vehiclesUpdated: 1, recordsUpdated: 0 });
+    expect(prismaMock.monthlyRecord.upsert).not.toHaveBeenCalled();
+  });
+
+  it("splits one driver amount across two vehicles same day (weight 1/2 each) and upserts monthly records", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "ai1" }]);
+    prismaMock.vehicle.findMany.mockResolvedValue([{ id: "v1" }, { id: "v2" }]);
+    prismaMock.dailyDriverAssignment.findMany.mockResolvedValue([
+      { driverId: "d1", vehicleId: "v1", date: "2026-03-01" },
+      { driverId: "d1", vehicleId: "v2", date: "2026-03-01" },
+    ]);
+    prismaMock.driverMonthlyAmount.findMany.mockResolvedValue([
+      { driverId: "d1", accountItemId: "ai1", amount: 100 },
+    ]);
+
+    const result = await runDriverAllocation("2026-03");
+
+    expect(result).toEqual({ vehiclesUpdated: 2, recordsUpdated: 2 });
+    expect(prismaMock.monthlyRecord.upsert).toHaveBeenCalledTimes(2);
+
+    const amounts = prismaMock.monthlyRecord.upsert.mock.calls.map(
+      (c) => (c[0] as { create: { amount: number }; update: { amount: number } }).create.amount
+    );
+    expect(amounts).toEqual(expect.arrayContaining([50, 50]));
+  });
+});

--- a/backend/src/lib/location-expense-allocation.test.ts
+++ b/backend/src/lib/location-expense-allocation.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  accountItem: { findMany: vi.fn() },
+  locationMonthlyExpense: { findMany: vi.fn() },
+  vehicle: { findMany: vi.fn() },
+  monthlyRecord: { findUnique: vi.fn(), upsert: vi.fn() },
+  $executeRawUnsafe: vi.fn(),
+}));
+
+vi.mock("./prisma.js", () => ({
+  prisma: prismaMock,
+}));
+
+import { runLocationExpenseAllocation } from "./location-expense-allocation.js";
+
+describe("runLocationExpenseAllocation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.$executeRawUnsafe.mockResolvedValue(0);
+  });
+
+  it("returns zeros when no location expense account items exist", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([]);
+    const result = await runLocationExpenseAllocation("2026-03");
+    expect(result).toEqual({ vehiclesUpdated: 0, recordsUpdated: 0 });
+    expect(prismaMock.locationMonthlyExpense.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns zeros when account items exist but no location expenses for yearMonth", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "ai1" }]);
+    prismaMock.locationMonthlyExpense.findMany.mockResolvedValue([]);
+    const result = await runLocationExpenseAllocation("2026-03");
+    expect(result).toEqual({ vehiclesUpdated: 0, recordsUpdated: 0 });
+    expect(prismaMock.vehicle.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns zeros when expenses exist but no vehicles at the locations", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "ai1" }]);
+    prismaMock.locationMonthlyExpense.findMany.mockResolvedValue([
+      { locationId: "loc1", accountItemId: "ai1", amount: 10000 },
+    ]);
+    prismaMock.vehicle.findMany.mockResolvedValue([]);
+    const result = await runLocationExpenseAllocation("2026-03");
+    // No vehicles → allocatedByVehicle is empty → 0 rows → recordsUpdated = 0
+    expect(result).toEqual({ vehiclesUpdated: 0, recordsUpdated: 0 });
+  });
+
+  it("splits expense equally across 2 vehicles at the same location", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "ai1" }]);
+    prismaMock.locationMonthlyExpense.findMany.mockResolvedValue([
+      { locationId: "loc1", accountItemId: "ai1", amount: 10000 },
+    ]);
+    prismaMock.vehicle.findMany.mockResolvedValue([
+      { id: "v1", locationId: "loc1" },
+      { id: "v2", locationId: "loc1" },
+    ]);
+
+    const result = await runLocationExpenseAllocation("2026-03");
+
+    expect(result.vehiclesUpdated).toBe(2);
+    expect(result.recordsUpdated).toBe(2);
+
+    // Should have called $executeRawUnsafe with INSERT containing 2 value rows
+    expect(prismaMock.$executeRawUnsafe).toHaveBeenCalledTimes(1);
+    const sql = prismaMock.$executeRawUnsafe.mock.calls[0][0] as string;
+    expect(sql).toContain("INSERT INTO MonthlyRecord");
+    expect(sql).toContain("5000"); // 10000 / 2 vehicles
+  });
+
+  it("handles multiple locations and account items independently", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([
+      { id: "ai1" },
+      { id: "ai2" },
+    ]);
+    prismaMock.locationMonthlyExpense.findMany.mockResolvedValue([
+      { locationId: "locA", accountItemId: "ai1", amount: 9000 },
+      { locationId: "locB", accountItemId: "ai2", amount: 6000 },
+    ]);
+    prismaMock.vehicle.findMany.mockResolvedValue([
+      { id: "vA1", locationId: "locA" },
+      { id: "vA2", locationId: "locA" },
+      { id: "vA3", locationId: "locA" },
+      { id: "vB1", locationId: "locB" },
+      { id: "vB2", locationId: "locB" },
+    ]);
+
+    const result = await runLocationExpenseAllocation("2026-03");
+
+    // locA: 3 vehicles * 1 item = 3 rows; locB: 2 vehicles * 1 item = 2 rows
+    expect(result.vehiclesUpdated).toBe(5);
+    expect(result.recordsUpdated).toBe(5);
+
+    const sql = prismaMock.$executeRawUnsafe.mock.calls[0][0] as string;
+    expect(sql).toContain("3000"); // 9000 / 3
+    expect(sql).toContain("3000"); // 6000 / 2
+  });
+
+  it("skips location expenses with zero amount", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "ai1" }]);
+    prismaMock.locationMonthlyExpense.findMany.mockResolvedValue([
+      { locationId: "loc1", accountItemId: "ai1", amount: 0 },
+    ]);
+    prismaMock.vehicle.findMany.mockResolvedValue([
+      { id: "v1", locationId: "loc1" },
+    ]);
+
+    const result = await runLocationExpenseAllocation("2026-03");
+    // amount is 0 → skipped in the loop → no rows
+    expect(result.vehiclesUpdated).toBe(0);
+    expect(result.recordsUpdated).toBe(0);
+    expect(prismaMock.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/lib/location-expense-proration.test.ts
+++ b/backend/src/lib/location-expense-proration.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isLocationExpenseProrationAccount } from "./location-expense-proration.js";
+
+describe("isLocationExpenseProrationAccount", () => {
+  it("returns true for known location expense codes", () => {
+    expect(isLocationExpenseProrationAccount("6150")).toBe(true);
+    expect(isLocationExpenseProrationAccount("6173")).toBe(true);
+  });
+
+  it("returns false for codes outside the list", () => {
+    expect(isLocationExpenseProrationAccount("6138")).toBe(false);
+    expect(isLocationExpenseProrationAccount("9999")).toBe(false);
+  });
+});

--- a/backend/src/lib/salary-daily-proration.test.ts
+++ b/backend/src/lib/salary-daily-proration.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPreviousYearMonth,
+  getSalaryDailyAmount,
+  isSalaryDailyProrationAccount,
+} from "./salary-daily-proration.js";
+
+describe("getPreviousYearMonth", () => {
+  it("returns previous month in same year", () => {
+    expect(getPreviousYearMonth("2026-03")).toBe("2026-02");
+  });
+
+  it("rolls from January to December of prior year", () => {
+    expect(getPreviousYearMonth("2026-01")).toBe("2025-12");
+  });
+});
+
+describe("getSalaryDailyAmount", () => {
+  it("uses run-count split when totalRunCount > 0 and runCount > 0", () => {
+    // monthly 30000, 10 runs in month, 3 runs this day -> 9000
+    expect(getSalaryDailyAmount(30000, 10, 3, 31)).toBe(9000);
+  });
+
+  it("falls back to equal daily split when totalRunCount is 0", () => {
+    expect(getSalaryDailyAmount(31000, 0, 0, 31)).toBe(1000);
+  });
+
+  it("returns 0 when monthly amount is 0", () => {
+    expect(getSalaryDailyAmount(0, 10, 3, 31)).toBe(0);
+  });
+
+  it("rounds to 2 decimal places", () => {
+    expect(getSalaryDailyAmount(100, 3, 1, 30)).toBeCloseTo(33.33, 2);
+  });
+});
+
+describe("isSalaryDailyProrationAccount", () => {
+  it("returns true for salary codes", () => {
+    expect(isSalaryDailyProrationAccount("6138")).toBe(true);
+    expect(isSalaryDailyProrationAccount("6147")).toBe(true);
+  });
+
+  it("returns false for other codes", () => {
+    expect(isSalaryDailyProrationAccount("6139")).toBe(false);
+    expect(isSalaryDailyProrationAccount("6150")).toBe(false);
+  });
+});

--- a/backend/src/lib/salary-run-count-allocation.test.ts
+++ b/backend/src/lib/salary-run-count-allocation.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  accountItem: { findMany: vi.fn() },
+  vehicle: { findMany: vi.fn() },
+  dailyDriverAssignment: { findMany: vi.fn() },
+  driverMonthlyAmount: { findMany: vi.fn() },
+  dailyOperatingRecord: { findMany: vi.fn() },
+  monthlyRecord: { findUnique: vi.fn(), upsert: vi.fn() },
+}));
+
+vi.mock("./prisma.js", () => ({
+  prisma: prismaMock,
+}));
+
+import { runSalaryRunCountAllocation } from "./salary-run-count-allocation.js";
+
+describe("runSalaryRunCountAllocation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.monthlyRecord.findUnique.mockResolvedValue(null);
+    prismaMock.monthlyRecord.upsert.mockResolvedValue({} as never);
+  });
+
+  it("returns zeros when no salary account items (6138/6147) exist", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([]);
+    const result = await runSalaryRunCountAllocation("2026-03");
+    expect(result).toEqual({ vehiclesUpdated: 0, recordsUpdated: 0 });
+    expect(prismaMock.vehicle.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns zeros when salary items exist but no vehicles", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "sal1" }]);
+    prismaMock.vehicle.findMany.mockResolvedValue([]);
+    const result = await runSalaryRunCountAllocation("2026-03");
+    expect(result).toEqual({ vehiclesUpdated: 0, recordsUpdated: 0 });
+    expect(prismaMock.dailyDriverAssignment.findMany).not.toHaveBeenCalled();
+  });
+
+  it("allocates salary based on run count: driver with 2 runs on v1 and 3 runs on v2", async () => {
+    // Setup: 1 salary item, 2 vehicles
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "sal1" }]);
+    prismaMock.vehicle.findMany.mockResolvedValue([
+      { id: "v1" },
+      { id: "v2" },
+    ]);
+
+    // Driver d1 assigned to v1 on March 1, and to v2 on March 1
+    prismaMock.dailyDriverAssignment.findMany.mockResolvedValue([
+      { driverId: "d1", vehicleId: "v1", date: "2026-03-01" },
+      { driverId: "d1", vehicleId: "v2", date: "2026-03-01" },
+    ]);
+
+    // d1 has 31000 salary per month for sal1
+    prismaMock.driverMonthlyAmount.findMany.mockResolvedValue([
+      { driverId: "d1", accountItemId: "sal1", amount: 31000 },
+    ]);
+
+    // v1 has 2 runs on March 1, v2 has 3 runs
+    prismaMock.dailyOperatingRecord.findMany.mockResolvedValue([
+      { vehicleId: "v1", date: "2026-03-01", runCount: 2 },
+      { vehicleId: "v2", date: "2026-03-01", runCount: 3 },
+    ]);
+
+    const result = await runSalaryRunCountAllocation("2026-03");
+
+    // March 2026 has 31 days
+    // daily unit price = 31000 / 31 = 1000
+    // v1: 1000 * 2 = 2000
+    // v2: 1000 * 3 = 3000
+    expect(result.vehiclesUpdated).toBe(2);
+    expect(result.recordsUpdated).toBe(2);
+
+    // Check upsert calls
+    expect(prismaMock.monthlyRecord.upsert).toHaveBeenCalledTimes(2);
+    const amounts = prismaMock.monthlyRecord.upsert.mock.calls.map(
+      (c) => (c[0] as { create: { amount: number } }).create.amount
+    );
+    expect(amounts).toContain(2000);
+    expect(amounts).toContain(3000);
+  });
+
+  it("skips vehicles with 0 run count (no allocation)", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "sal1" }]);
+    prismaMock.vehicle.findMany.mockResolvedValue([{ id: "v1" }]);
+
+    prismaMock.dailyDriverAssignment.findMany.mockResolvedValue([
+      { driverId: "d1", vehicleId: "v1", date: "2026-03-01" },
+    ]);
+
+    prismaMock.driverMonthlyAmount.findMany.mockResolvedValue([
+      { driverId: "d1", accountItemId: "sal1", amount: 31000 },
+    ]);
+
+    // v1 has 0 runs on that day
+    prismaMock.dailyOperatingRecord.findMany.mockResolvedValue([
+      { vehicleId: "v1", date: "2026-03-01", runCount: 0 },
+    ]);
+
+    const result = await runSalaryRunCountAllocation("2026-03");
+
+    // runCount is 0 → amount stays at 0 → no change from old (null → 0) → no upsert
+    expect(result.vehiclesUpdated).toBe(1);
+    expect(result.recordsUpdated).toBe(0);
+  });
+
+  it("skips driver amounts that are zero", async () => {
+    prismaMock.accountItem.findMany.mockResolvedValue([{ id: "sal1" }]);
+    prismaMock.vehicle.findMany.mockResolvedValue([{ id: "v1" }]);
+
+    prismaMock.dailyDriverAssignment.findMany.mockResolvedValue([
+      { driverId: "d1", vehicleId: "v1", date: "2026-03-01" },
+    ]);
+
+    prismaMock.driverMonthlyAmount.findMany.mockResolvedValue([
+      { driverId: "d1", accountItemId: "sal1", amount: 0 },
+    ]);
+
+    prismaMock.dailyOperatingRecord.findMany.mockResolvedValue([
+      { vehicleId: "v1", date: "2026-03-01", runCount: 5 },
+    ]);
+
+    const result = await runSalaryRunCountAllocation("2026-03");
+
+    // amount 0 → daily unit price 0/31 = 0 → skipped in dailyUnitPriceByDriver
+    // allocatedByVehicle totals remain 0 → no upsert
+    expect(result.vehiclesUpdated).toBe(1);
+    expect(result.recordsUpdated).toBe(0);
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,5 +16,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    pool: "forks",
+  },
+});

--- a/docs/issues/Izumi_Issue-Requests-Repo/955/dev.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/955/dev.md
@@ -1,0 +1,64 @@
+# Development log — Issue #955
+
+**Issue:** [003] P2: 自動テストの導入  
+**Repository:** TeckVeho/Izumi_Issue-Requests-Repo (work in `vehicle-pl-system`)  
+**Branch context:** `955-feat-automated-tests` (local; not committed by this workflow)
+
+## Approach
+
+- **TDD-style:** Vitest + Supertest, `createApp()` extraction, unit tests (pure libs + Prisma-mocked allocators), HTTP contract tests for sync routes.
+- **Scope:** Backend only (`backend/`). No CI, no root `package.json` test script (per issue).
+- **plan.md alignment:** Extended mocks and cases to match §1.4–§1.9 (see below).
+
+## Implemented
+
+| Area | Detail |
+|------|--------|
+| **Tooling** | `vitest`, `supertest`, `@types/supertest`; scripts `npm test` / `npm run test:watch` |
+| **App split** | `src/app.ts` exports `createApp()`; `src/index.ts` only listens |
+| **Pure unit tests** | `salary-daily-proration.test.ts`, `location-expense-proration.test.ts`, `calc.test.ts` |
+| **§1.7** | `account-item-filter.test.ts` — `accountItemEffectiveWhere` shape |
+| **§1.8** | `driver-allocation.test.ts` — full prisma stub: no items, no vehicles, zero amounts, **two-vehicle same-day weight split** (50/50) |
+| **§1.8 (second module)** | `salary-run-count-allocation.test.ts` — no salary items, no vehicles, **happy-path run-count allocation** (2 vs 3 runs split), zero-runcount, zero-amount edges |
+| **§1.8 (third module)** | `location-expense-allocation.test.ts` — no items, no expenses, no vehicles, **equal split across 2 vehicles**, multi-location/multi-item, zero-amount skip |
+| **§1.9** | `sync-routes.contract.test.ts` — **8 sync routes covered**: vehicles (401/403/400/200/Bearer), courses (400/200), driver-assignments (400 variants), **drivers** (400/200/401/403), **driver-monthly-amounts** (400 variants/200), **daily-operating** (400 variants/200), **location-monthly-expenses** (400 variants/200/401/403), **vehicle-monthly-costs** (400 variants/200/401/403) |
+| **TS build** | `tsconfig.json` excludes `**/*.test.ts` |
+
+## Commands run
+
+```bash
+cd backend && npm test
+cd backend && npm run build
+```
+
+**Results:** 69 tests passed; `tsc` succeeded.
+
+## Test summary
+
+| Test file | Tests |
+|-----------|-------|
+| `salary-daily-proration.test.ts` | 8 |
+| `location-expense-proration.test.ts` | 2 |
+| `calc.test.ts` | 7 |
+| `account-item-filter.test.ts` | 1 |
+| `driver-allocation.test.ts` | 4 |
+| `salary-run-count-allocation.test.ts` | 5 |
+| `location-expense-allocation.test.ts` | 6 |
+| `sync-routes.contract.test.ts` | 36 |
+| **Total** | **69** |
+
+## Decisions
+
+- **Vitest** over Jest for native ESM alignment with `"type": "module"` and `NodeNext`.
+- **Contract tests** use a **partial `prisma` stub** for routes under test; allocation modules called by routes are fully mocked to isolate route-level validation.
+- **JWT** in tests uses the same default secret as `auth.ts` (`dev-secret-change-in-production`).
+
+## Not done (out of scope or follow-up)
+
+- CI wiring (explicitly out of issue scope).
+- Coverage thresholds / `@vitest/coverage-v8`.
+- Integration tests with real test DB (plan optional stretch).
+
+## Git
+
+- **No commits** were made (per `/dev` rules). All changes remain unstaged/uncommitted for `/test` and review.

--- a/docs/issues/Izumi_Issue-Requests-Repo/955/issue.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/955/issue.md
@@ -1,0 +1,184 @@
+# Issue #955 — [003] P2: 自動テストの導入
+
+## Context / Codebase Paths (from pre-questions)
+
+```yaml
+repository: TeckVeho/Izumi_Issue-Requests-Repo
+repo: Izumi_Issue-Requests-Repo
+issue_url: https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/955
+github_project_v2_id: PVT_kwDOCjwUv84Ajq0M
+github_project_title: Izumi_Issue
+frontend_path: .
+backend_path: ./backend
+migrations_path:
+api_docs_path:
+tests_path:
+workspace_root: .
+```
+
+**Note:** Scope is **vehicle-pl-system**: Next.js app at repo root; API and allocation logic live under **`./backend`** (`backend/src/lib/`, sync routes under `backend/src/routes/`). Prisma schema is at `./backend/prisma/schema.prisma` (no `prisma/migrations` tree in-repo yet). Paths are relative to **`/var/www/html/vehicle-pl-system`** (this workspace).
+
+---
+
+## Metadata
+
+| Field | Value |
+|--------|--------|
+| **Title** | [003] P2: 自動テストの導入 |
+| **State** | OPEN |
+| **URL** | https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/955 |
+| **Created** | 2026-03-25T12:24:21Z |
+| **Updated** | 2026-03-25T12:31:28Z |
+| **Assignees** | tungnt183855 |
+| **Labels** | _(none)_ |
+
+---
+
+## Description (summary)
+
+Introduce a test runner (Vitest or Jest) on the **backend**, run via `npm test`. Add unit tests for allocation/proration modules under `backend/src/lib/` (e.g. driver-allocation, location-expense-allocation, location-expense-proration, salary-daily-proration, salary-run-count-allocation) and API contract tests for main sync routes (vehicles, courses, driver-assignments, etc.). **CI / deploy pipeline is out of scope.**
+
+---
+
+## Implementation checklist
+
+- [ ] Add Vitest or Jest to **backend**; `npm test` runs tests locally.
+- [ ] Unit tests for allocation/proration logic in `backend/src/lib/` (driver-allocation, location-expense-allocation, salary-daily-proration, etc.).
+- [ ] API contract tests for main sync routes (vehicles, courses, driver-assignments, …).
+- [ ] Meaningful coverage of the main paths for the above logic.
+
+---
+
+## Reference pointers (from issue body)
+
+- `./docs/engineering-backlog.md` P2
+- `backend/src/lib/driver-allocation.ts`
+- `backend/src/lib/location-expense-allocation.ts`
+- `backend/src/lib/salary-daily-proration.ts`
+
+---
+
+## Notes / review
+
+- Parent issue source file cited: `003-自動テストの導入.md` (vehicle-pl-system/issues).
+- **Do not** commit workflow artifacts unless the team’s `/pr` step says otherwise; this file is for `/plan`, `/breakdown`, `/dev` context.
+
+---
+
+## Description (full body from GitHub)
+
+See issue URL for the canonical copy. Snapshot below mirrors the fetched `body` at documentation time.
+
+```markdown
+# P2: 自動テストの導入
+
+## 1. 概要 (Overview)
+
+### 背景 (Background)
+
+* **現状の課題:** ルート・バックエンドの `package.json` に Vitest/Jest 等のテストランナー設定が無い。配賦・按分ロジック（driver-allocation、location-expense-allocation、salary-daily-proration 等）や sync API の品質保証が手動に依存している。
+* **ビジネス要求:** リグレッションを防ぎ、リファクタリング時の安全性を高めるため、自動テストを導入すること。
+* **ユーザーストーリー:** 開発者として、私は `npm test` で主要ロジックの動作を確認し、変更時のリグレッションを早期に検知したい。
+
+### 達成目標 (Goal)
+
+* **あるべき姿:** バックエンドにテストランナーが導入され、配賦・按分ロジックおよび主要 sync API の主要パスがテストでカバーされていること。
+* **完了条件 (Definition of Done):**
+* [ ] バックエンドに Vitest または Jest を導入し、`npm test` で実行可能であること。
+* [ ] 配賦・按分ロジック（driver-allocation、location-expense-allocation、salary-daily-proration 等）のユニットテストが実装されていること。
+* [ ] 主要 sync ルート（vehicles 等）の API 契約テストが実装されていること。
+* [ ] 上記ロジックの主要パスがカバーされていること。
+
+---
+
+## 2. 仕様 (Specification)
+
+### 機能要件 (Functional Requirements)
+
+* バックエンドに Vitest または Jest を導入し、`npm test` で実行可能にすること。
+* `backend/src/lib/` の driver-allocation、location-expense-allocation、location-expense-proration、salary-daily-proration、salary-run-count-allocation 等のユニットテストを実装すること。
+* 主要 sync ルート（vehicles、courses、driver-assignments 等）の API 契約テストを実装すること。
+* テストはローカルで実行可能であること。
+
+### タスクタイプ
+技術改善
+
+### 添付ファイル
+
+### 参考資料
+- [engineering-backlog.md](../docs/engineering-backlog.md) P2
+- `backend/src/lib/driver-allocation.ts`
+- `backend/src/lib/location-expense-allocation.ts`
+- `backend/src/lib/salary-daily-proration.ts`
+
+### メモ
+- CI への組み込み、デプロイパイプラインはスコープ外（インフラに触れない範囲）
+
+### UI/UX (あれば)
+* **デザイン:** なし
+* **コンポーネント:** なし
+
+### 起票者
+-
+
+---
+# P2: Giới thiệu kiểm thử tự động
+
+## 1. Tổng quan
+
+### Bối cảnh
+
+* **Vấn đề hiện tại:** `package.json` của root và backend không có cấu hình test runner như Vitest/Jest. Đảm bảo chất lượng logic phân bổ, phân bổ tỷ lệ (driver-allocation, location-expense-allocation, salary-daily-proration, v.v.) và sync API phụ thuộc vào thao tác thủ công.
+* **Yêu cầu kinh doanh:** Giới thiệu kiểm thử tự động để ngăn chặn hồi quy và tăng độ an toàn khi refactoring.
+* **Câu chuyện người dùng:** Là nhà phát triển, tôi muốn xác nhận hoạt động của logic chính qua `npm test` và phát hiện sớm hồi quy khi thay đổi.
+
+### Mục tiêu đạt được
+
+* **Hình ảnh lý tưởng:** Test runner được giới thiệu vào backend, và các đường dẫn chính của logic phân bổ, phân bổ tỷ lệ và sync API chính được bao phủ bởi kiểm thử.
+* **Điều kiện hoàn thành (Definition of Done):**
+* [ ] Vitest hoặc Jest được giới thiệu vào backend và có thể chạy qua `npm test`.
+* [ ] Unit test cho logic phân bổ, phân bổ tỷ lệ (driver-allocation, location-expense-allocation, salary-daily-proration, v.v.) được triển khai.
+* [ ] API contract test cho các sync route chính (vehicles, v.v.) được triển khai.
+* [ ] Các đường dẫn chính của logic trên được bao phủ.
+
+---
+## 2. Thông số kỹ thuật (Specification)
+
+### Yêu cầu chức năng (Functional Requirements)
+
+* Giới thiệu Vitest hoặc Jest vào backend và có thể chạy qua `npm test`.
+* Triển khai unit test cho driver-allocation, location-expense-allocation, location-expense-proration, salary-daily-proration, salary-run-count-allocation trong `backend/src/lib/`.
+* Triển khai API contract test cho các sync route chính (vehicles, courses, driver-assignments, v.v.).
+* Kiểm thử có thể chạy cục bộ.
+
+### Loại nhiệm vụ
+Cải thiện kỹ thuật
+
+### Tài liệu đính kèm
+
+### Tài liệu tham khảo
+- [engineering-backlog.md](../docs/engineering-backlog.md) P2
+- `backend/src/lib/driver-allocation.ts`
+- `backend/src/lib/location-expense-allocation.ts`
+- `backend/src/lib/salary-daily-proration.ts`
+
+### Ghi chú
+- Tích hợp CI, pipeline triển khai nằm ngoài phạm vi (không chạm vào hạ tầng)
+
+### UI/UX (nếu có)
+* **Thiết kế:** Không
+* **Thành phần:** Không
+
+### Người khởi tạo
+-
+
+## Implementation Tasks
+- [ ] テストランナー導入: バックエンドに Vitest または Jest を導入し、`npm test` で実行可能にする
+- [ ] ユニットテスト: driver-allocation、location-expense-allocation、salary-daily-proration 等のユニットテスト
+- [ ] 契約テスト: 主要 sync ルート（vehicles、courses、driver-assignments 等）の API 契約テスト
+
+
+---
+
+_Source file: `003-自動テストの導入.md` (vehicle-pl-system/issues)_
+```

--- a/docs/issues/Izumi_Issue-Requests-Repo/955/plan.md
+++ b/docs/issues/Izumi_Issue-Requests-Repo/955/plan.md
@@ -1,0 +1,242 @@
+# Issue #955: [003] P2: 自動テストの導入 - Implementation Plan
+
+## 概要 (Overview)
+
+**Requirements:** Add a test runner (Vitest or Jest) under `backend/`, expose **`npm test`**, implement **unit tests** for allocation / proration logic in `backend/src/lib/`, and **API contract tests** for main **sync** routes (`POST .../sync`) such as vehicles, courses, and driver-assignments. **CI and deploy pipelines are out of scope** (per issue).
+
+**Current state:** `backend/package.json` has no `test` script and no Vitest/Jest devDependencies. The API is started from `backend/src/index.ts`, which creates `express()`, mounts middleware and `apiRouter`, and calls `app.listen()` immediately—there is no exported `app` for HTTP testing. Many “allocation” modules (`driver-allocation.ts`, `location-expense-allocation.ts`, `salary-run-count-allocation.ts`, etc.) are **async functions tightly coupled to Prisma**; a smaller set of **pure helpers** exists (e.g. `salary-daily-proration.ts`, `location-expense-proration.ts`, `calc.ts`).
+
+**Target state:** Developers run **`cd backend && npm test`** locally. Tests cover **pure logic** with fast unit tests, and **sync route contracts** (status codes, error shapes for invalid bodies, success JSON shape) using an in-memory Express app and controlled Prisma access (mocked client and/or dedicated test DB—team choice).
+
+---
+
+## FE (Frontend)
+
+### 1. Files need to edit:
+
+**None for this issue.** The GitHub issue explicitly scopes work to the backend and lists no UI. The Next.js app at the repository root (`./`) does not need changes for introducing backend tests.
+
+If the team later wants a root-level script (e.g. `npm test` at monorepo root delegating to `backend`), that can be a follow-up and is **not** required by the issue DoD.
+
+---
+
+## BE (Backend)
+
+### 1. Files need to edit:
+
+#### 1.1. File: `backend/package.json`
+
+##### 1.1.1. Add test runner and scripts
+
+Add **`"test"`** (and optionally **`"test:watch"`**) scripts. Prefer **Vitest** (native ESM, aligns with `"type": "module"` and `tsx` usage).
+
+**現在の実装:**
+
+- Scripts only include `dev`, `build`, `start`, and Prisma helpers; no test entry.
+
+**変更内容:**
+
+- Add devDependencies: `vitest`, `supertest`, and `@types/supertest` (for HTTP contract tests).
+- Add `"test": "vitest run"` and `"test:watch": "vitest"`.
+- Optionally add `vitest` config path via `"test": "vitest run --config vitest.config.ts"` once config exists.
+
+---
+
+#### 1.2. File: `backend/vitest.config.ts` (new)
+
+##### 1.2.1. Vitest configuration for Node + ESM
+
+**変更内容:**
+
+- Set `environment: "node"`, align with `tsconfig` paths / ESM (`module: NodeNext`).
+- Include patterns such as `src/**/*.test.ts` or `src/**/__tests__/**/*.ts`.
+- If tests import `.js` extensions like production code, ensure `resolve` / `deps` settings match the existing import style (`../lib/foo.js`).
+
+---
+
+#### 1.3. File: `backend/src/index.ts` and/or `backend/src/app.ts` (new)
+
+##### 1.3.1. Export Express `app` without listening (for `supertest`)
+
+**現在の実装** (`backend/src/index.ts` lines 1–23):
+
+- Builds `app`, mounts `/api`, then calls `app.listen(PORT, ...)`.
+
+**変更内容:**
+
+- Extract **`createApp()`** or move middleware + `apiRouter` setup into **`app.ts`** that exports `app` (or a factory).
+- Keep `index.ts` as the entry that imports `app`, calls `listen`, and logs—so production behavior is unchanged.
+- Contract tests import `app` and use `supertest(app)` without opening a real port.
+
+---
+
+#### 1.4. File: `backend/src/lib/salary-daily-proration.ts`
+
+##### 1.4.1. Unit tests for pure helpers
+
+**現在の実装** (lines 11–52):
+
+- `SALARY_DAILY_PRORATION_CODES`, `isSalaryDailyProrationAccount`, `getPreviousYearMonth`, `getSalaryDailyAmount` — **no Prisma** in this file.
+
+**変更内容:**
+
+- Add `salary-daily-proration.test.ts` (or colocated `*.test.ts`):
+  - `getPreviousYearMonth`: boundary cases (January → previous year December).
+  - `getSalaryDailyAmount`: run-count path vs fallback when `totalRunCountInMonth === 0`, rounding to 2 decimals.
+  - `isSalaryDailyProrationAccount`: membership for `6138` / `6147` and rejection of others.
+
+---
+
+#### 1.5. File: `backend/src/lib/location-expense-proration.ts`
+
+##### 1.5.1. Unit tests for `isLocationExpenseProrationAccount`
+
+**現在の実装** (lines 8–35):
+
+- `LOCATION_EXPENSE_PRORATION_CODES` and `isLocationExpenseProrationAccount`.
+
+**変更内容:**
+
+- Sample codes in/out of the list; ensures regression if codes array changes.
+
+---
+
+#### 1.6. File: `backend/src/lib/calc.ts`
+
+##### 1.6.1. Unit tests for `calcNetRevenue`, `calcTotalExpense`, `calcSalesRatio`, category helpers
+
+**現在の実装** (lines 8–49):
+
+- Pure functions over `Map` / `Set` and simple math.
+
+**変更内容:**
+
+- Table-driven tests for zero net revenue, empty maps, and typical ratios.
+
+---
+
+#### 1.7. File: `backend/src/lib/account-item-filter.ts` (if exports are stable)
+
+##### 1.7.1. Optional unit tests
+
+**変更内容:**
+
+- If the module contains pure predicates or filters, add focused tests; skip or defer if it is only thin Prisma wrappers.
+
+---
+
+#### 1.8. Files: `backend/src/lib/driver-allocation.ts`, `location-expense-allocation.ts`, `salary-run-count-allocation.ts`, etc.
+
+##### 1.8.1. Unit tests with mocked Prisma
+
+**現在の実装:**
+
+- Example: `runDriverAllocation` in `driver-allocation.ts` (from line 13) uses **`prisma.accountItem.findMany`**, **`prisma.vehicle.findMany`**, assignments, driver amounts, and **`prisma.monthlyRecord`** — heavy DB usage.
+
+**変更内容:**
+
+- Use **`vi.mock("../lib/prisma.js")`** (or equivalent) to provide an in-memory fake returning controlled graphs.
+- Cover **edge paths** called out in issue: no vehicles, no driver-related items, zero amounts, weight aggregation (lines 57–107 area).
+- Prioritize **one representative module fully mocked** (e.g. driver-allocation or salary-run-count-allocation), then extend patterns to others so DoD “main paths” is satisfied without duplicating every DB branch.
+
+---
+
+#### 1.9. Files: `backend/src/routes/vehicles.ts`, `courses.ts`, `driver-assignments.ts`
+
+##### 1.9.1. API contract tests for `POST /sync`
+
+**現在の実装:**
+
+- `vehicles.ts` (lines 30–121): `POST /sync` with `requireRole(ROLES.MASTER)`, validates `vehicles` array, returns `400` when missing, JSON body `{ synced, skippedCount, results }` on success.
+- `courses.ts` (lines 22+): `POST /sync` requires `courses` array (`courses` payload key), `400` if not array.
+- `driver-assignments.ts` (lines 29+): validates `yearMonth`, `records`, date format, `yearMonth` regex.
+
+**変更内容:**
+
+- With **`createToken`** / **`setAuthCookie`** from `auth.ts` (lines 16–32) or **`Authorization: Bearer`** (see `requireAuth` line 53), authenticate as a user whose **`role`** is in **`ROLES.MASTER`** (`auth.ts` lines 100–111: e.g. `"DX"` or `"DX管理者"`).
+- **Prisma** must resolve that user: `requireAuth` loads `prisma.user.findUnique` (`auth.ts` lines 67–70). Options:
+  - **Integration:** seed minimal `User` + use real `DATABASE_URL` test database (docker or `.env.test`), or
+  - **Mock:** mock `prisma` in auth middleware path (harder); prefer integration for auth + contract.
+- Contract assertions:
+  - **401** without cookie/token.
+  - **403** with valid JWT but role not in `MASTER` (e.g. VIEW-only role).
+  - **400** for invalid body (`vehicles` / `courses` / `yearMonth`+`records`).
+  - **200** shape keys match existing handlers (do not assert full DB side effects unless using a real DB).
+
+---
+
+### 2. Optional / follow-up (not blocking DoD)
+
+- **`backend/tsconfig.json`**: Add `"types": ["vitest/globals"]` only if using globals; otherwise `import { describe, it, expect } from "vitest"`.
+- **Root `package.json`**: `npm test` delegating to backend—optional.
+- **Coverage**: `vitest run --coverage` with `@vitest/coverage-v8`—optional unless team mandates.
+
+---
+
+## 実装順序 (Implementation Order)
+
+1. **Backend — 基盤**
+
+   - Add Vitest + Supertest + scripts (`package.json`).
+   - Add `vitest.config.ts`.
+   - Refactor **`index.ts` / `app.ts`** so `app` is testable.
+
+2. **Backend — ユニット（純粋関数）**
+
+   - `salary-daily-proration.ts`, `location-expense-proration.ts`, `calc.ts` tests (fast, no DB).
+
+3. **Backend — ユニット（Prisma mock）**
+
+   - At least one allocation module (`driver-allocation` or `salary-run-count-allocation`) with mocked `prisma` for main branches.
+
+4. **Backend — API 契約テスト**
+
+   - Auth helper for MASTER user + `POST /api/vehicles/sync`, `/courses/sync`, `/driver-assignments/sync` contract cases (401/403/400/200 shape).
+
+5. **統合テスト**
+
+   - If using a real test DB: run Prisma migrate/push against test schema and one happy-path sync (optional stretch beyond minimal contract tests).
+
+6. **Frontend**
+
+   - None.
+
+---
+
+## 見積もり工数 (Estimated Effort)
+
+- **Backend**: **14–22 時間**
+
+  - Vitest/Supertest + app export + config: **2–3 h**
+  - Pure lib tests (`salary-daily-proration`, `location-expense-proration`, `calc`): **3–4 h**
+  - Prisma-mocked allocation tests (1–2 modules): **4–8 h**
+  - Sync route contract tests + auth fixture: **5–7 h**
+
+- **Frontend**: **0 時間**
+
+**合計**: **14–22 時間**
+
+---
+
+## 技術的な注意事項 (Technical Notes)
+
+1. **パフォーマンス考慮:**
+
+   - Prefer **pure unit tests** and **mocked Prisma** for allocation logic to keep CI/local runs fast; reserve full DB integration for a few smoke tests if needed.
+
+2. **UX 考慮:**
+
+   - Not applicable (no UI). Developer UX: `npm test` / `npm run test:watch` should be documented in backend README or issue notes.
+
+3. **データ整合性:**
+
+   - Contract tests that use a **real database** must use an isolated `DATABASE_URL` (test DB) and avoid touching production data. Clear or reset state between tests if needed.
+
+4. **既存機能との互換性:**
+
+   - Refactoring `index.ts` must **not** change route paths, middleware order, or CORS/cookie behavior; only **extract** `app` creation for testability.
+   - JWT secret in tests should match `JWT_SECRET` used when signing tokens (`auth.ts` line 5).
+
+5. **Runner choice:**
+
+   - **Vitest** is recommended over Jest for ESM-first `backend` (`"type": "module"`, `NodeNext`). If Jest is chosen instead, extra ESM config is required—document any deviation.


### PR DESCRIPTION
## Summary

Implements automated testing for the **vehicle-pl-system** backend as specified in [Izumi_Issue-Requests-Repo#955](https://github.com/TeckVeho/Izumi_Issue-Requests-Repo/issues/955).

- Adds **Vitest** and **Supertest** with `npm test` / `npm run test:watch` in `backend/`.
- Extracts **`createApp()`** into `backend/src/app.ts` so routes can be exercised without binding a port.
- **Unit tests** for pure helpers and Prisma-mocked allocation flows (`driver-allocation`, `location-expense-allocation`, `salary-run-count-allocation`, etc.).
- **Contract tests** for sync routes (auth, validation, response shape for vehicles/courses/driver-assignments).
- Issue workflow notes under `docs/issues/Izumi_Issue-Requests-Repo/955/` (issue, plan, dev).

## How to verify

```bash
cd backend && npm test && npm run build
```

## Scope

- CI wiring is **out of scope** for the Izumi issue; this PR is local test runner + tests only.


Made with [Cursor](https://cursor.com)