### PR TITLE
feat(backend): require Drive folder for PL spreadsheet discovery

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,3 +27,9 @@ CORS_ORIGIN="http://localhost:3000"
 # - Uploaded .xlsx files: downloaded with files.get(alt=media)
 # Both paths return an .xlsx Buffer parsed by `read-excel-file/node`.
 # GOOGLE_SERVICE_ACCOUNT_JSON='{"type":"service_account",...}'
+#
+# Required for auto-discovery of 損益計算資料 files (direct children only).
+# Set GOOGLE_DRIVE_FOLDER_ID or google_drive_folder_id. Share folder with SA as Viewer.
+# If unset: no folder listing → Locations without spreadsheetId cannot auto-resolve.
+# GOOGLE_DRIVE_FOLDER_ID=
+# google_drive_folder_id=

--- a/backend/src/lib/google-drive-client.test.ts
+++ b/backend/src/lib/google-drive-client.test.ts
@@ -1,18 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { googleAuthMock, driveFactoryMock, filesGetMock, filesExportMock } =
-  vi.hoisted(() => {
-    const googleAuthMock = vi.fn();
-    const filesGetMock = vi.fn();
-    const filesExportMock = vi.fn();
-    const driveFactoryMock = vi.fn(() => ({
-      files: {
-        get: filesGetMock,
-        export: filesExportMock,
-      },
-    }));
-    return { googleAuthMock, driveFactoryMock, filesGetMock, filesExportMock };
-  });
+const {
+  googleAuthMock,
+  driveFactoryMock,
+  filesGetMock,
+  filesExportMock,
+  filesListMock,
+} = vi.hoisted(() => {
+  const googleAuthMock = vi.fn();
+  const filesGetMock = vi.fn();
+  const filesExportMock = vi.fn();
+  const filesListMock = vi.fn();
+  const driveFactoryMock = vi.fn(() => ({
+    files: {
+      get: filesGetMock,
+      export: filesExportMock,
+      list: filesListMock,
+    },
+  }));
+  return {
+    googleAuthMock,
+    driveFactoryMock,
+    filesGetMock,
+    filesExportMock,
+    filesListMock,
+  };
+});
 
 vi.mock("googleapis", () => ({
   google: {
@@ -25,12 +38,34 @@ vi.mock("googleapis", () => ({
 import {
   downloadDriveFileAsXlsxBuffer,
   getDriveClient,
+  getGoogleDriveFolderIdFromEnv,
+  listSharedPlSpreadsheetFileRefs,
   MIME_GOOGLE_SHEETS,
   MIME_XLSX,
   resetGoogleDriveClientForTests,
 } from "./google-drive-client.js";
 
 const originalEnv = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+const savedDriveFolderUpper = process.env.GOOGLE_DRIVE_FOLDER_ID;
+const savedDriveFolderLower = process.env.google_drive_folder_id;
+
+function restoreDriveFolderEnv(): void {
+  if (savedDriveFolderUpper === undefined) {
+    delete process.env.GOOGLE_DRIVE_FOLDER_ID;
+  } else {
+    process.env.GOOGLE_DRIVE_FOLDER_ID = savedDriveFolderUpper;
+  }
+  if (savedDriveFolderLower === undefined) {
+    delete process.env.google_drive_folder_id;
+  } else {
+    process.env.google_drive_folder_id = savedDriveFolderLower;
+  }
+}
+
+function clearDriveFolderEnv(): void {
+  delete process.env.GOOGLE_DRIVE_FOLDER_ID;
+  delete process.env.google_drive_folder_id;
+}
 
 const minimalServiceAccountJson = JSON.stringify({
   type: "service_account",
@@ -47,6 +82,7 @@ describe("getDriveClient", () => {
     resetGoogleDriveClientForTests();
     vi.clearAllMocks();
     delete process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+    clearDriveFolderEnv();
   });
 
   afterEach(() => {
@@ -56,6 +92,7 @@ describe("getDriveClient", () => {
     } else {
       process.env.GOOGLE_SERVICE_ACCOUNT_JSON = originalEnv;
     }
+    restoreDriveFolderEnv();
   });
 
   it("throws when GOOGLE_SERVICE_ACCOUNT_JSON is not set", () => {
@@ -135,6 +172,7 @@ describe("downloadDriveFileAsXlsxBuffer", () => {
     resetGoogleDriveClientForTests();
     vi.clearAllMocks();
     process.env.GOOGLE_SERVICE_ACCOUNT_JSON = minimalServiceAccountJson;
+    clearDriveFolderEnv();
   });
 
   afterEach(() => {
@@ -144,6 +182,7 @@ describe("downloadDriveFileAsXlsxBuffer", () => {
     } else {
       process.env.GOOGLE_SERVICE_ACCOUNT_JSON = originalEnv;
     }
+    restoreDriveFolderEnv();
   });
 
   it("rejects empty fileId before hitting Drive", async () => {
@@ -208,5 +247,79 @@ describe("downloadDriveFileAsXlsxBuffer", () => {
     await expect(downloadDriveFileAsXlsxBuffer("file-3")).rejects.toThrow(
       "drive boom"
     );
+  });
+});
+
+describe("getGoogleDriveFolderIdFromEnv", () => {
+  beforeEach(() => {
+    clearDriveFolderEnv();
+  });
+
+  afterEach(() => {
+    restoreDriveFolderEnv();
+  });
+
+  it("returns undefined when unset or whitespace-only", () => {
+    expect(getGoogleDriveFolderIdFromEnv()).toBeUndefined();
+    process.env.GOOGLE_DRIVE_FOLDER_ID = "   ";
+    process.env.google_drive_folder_id = "   ";
+    expect(getGoogleDriveFolderIdFromEnv()).toBeUndefined();
+  });
+
+  it("returns trimmed id from google_drive_folder_id when upper unset", () => {
+    process.env.google_drive_folder_id = "  abcFolder123  ";
+    expect(getGoogleDriveFolderIdFromEnv()).toBe("abcFolder123");
+  });
+
+  it("prefers GOOGLE_DRIVE_FOLDER_ID over google_drive_folder_id", () => {
+    process.env.GOOGLE_DRIVE_FOLDER_ID = "upperId";
+    process.env.google_drive_folder_id = "lowerId";
+    expect(getGoogleDriveFolderIdFromEnv()).toBe("upperId");
+  });
+});
+
+describe("listSharedPlSpreadsheetFileRefs", () => {
+  beforeEach(() => {
+    resetGoogleDriveClientForTests();
+    vi.clearAllMocks();
+    process.env.GOOGLE_SERVICE_ACCOUNT_JSON = minimalServiceAccountJson;
+    clearDriveFolderEnv();
+  });
+
+  afterEach(() => {
+    resetGoogleDriveClientForTests();
+    if (originalEnv === undefined) {
+      delete process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+    } else {
+      process.env.GOOGLE_SERVICE_ACCOUNT_JSON = originalEnv;
+    }
+    restoreDriveFolderEnv();
+  });
+
+  it("returns empty list and skips Drive when no folder id configured", async () => {
+    const refs = await listSharedPlSpreadsheetFileRefs();
+
+    expect(refs).toEqual([]);
+    expect(filesListMock).not.toHaveBeenCalled();
+    expect(driveFactoryMock).not.toHaveBeenCalled();
+  });
+
+  it("lists direct children of folder when google_drive_folder_id is set", async () => {
+    process.env.google_drive_folder_id = "folderABC";
+    filesListMock.mockResolvedValueOnce({
+      data: { files: [{ id: "b", name: "損益計算資料_y" }], nextPageToken: null },
+    });
+
+    const refs = await listSharedPlSpreadsheetFileRefs();
+
+    expect(refs).toEqual([{ id: "b", name: "損益計算資料_y" }]);
+    expect(filesListMock).toHaveBeenCalledWith({
+      q: "'folderABC' in parents and trashed = false and name contains '損益計算資料'",
+      fields: "nextPageToken, files(id, name)",
+      pageSize: 100,
+      pageToken: undefined,
+      supportsAllDrives: true,
+      includeItemsFromAllDrives: true,
+    });
   });
 });

--- a/backend/src/lib/google-drive-client.ts
+++ b/backend/src/lib/google-drive-client.ts
@@ -113,18 +113,20 @@ export interface DriveFileRef {
   name: string;
 }
 
-/**
- * Lists files visible to the service account (sharedWithMe) whose name contains
- * {@link DRIVE_PL_FILENAME_MARKER}. Paginates; does not throw on empty list.
- */
-export async function listSharedPlSpreadsheetFileRefs(): Promise<DriveFileRef[]> {
-  const drive = getDriveClient();
-  const marker = DRIVE_PL_FILENAME_MARKER.replace(/'/g, "\\'");
+/** Drive query string escape for values wrapped in single quotes. */
+function driveQueryLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+async function listDriveFilesByQuery(
+  drive: drive_v3.Drive,
+  q: string
+): Promise<DriveFileRef[]> {
   const out: DriveFileRef[] = [];
   let pageToken: string | undefined;
   do {
     const res = await drive.files.list({
-      q: `sharedWithMe = true and trashed = false and name contains '${marker}'`,
+      q,
       fields: "nextPageToken, files(id, name)",
       pageSize: 100,
       pageToken,
@@ -137,6 +139,37 @@ export async function listSharedPlSpreadsheetFileRefs(): Promise<DriveFileRef[]>
     pageToken = res.data.nextPageToken ?? undefined;
   } while (pageToken);
   return out;
+}
+
+/**
+ * Folder ID for 損益計算資料 workbook discovery. First non-whitespace wins:
+ * `GOOGLE_DRIVE_FOLDER_ID`, then `google_drive_folder_id`.
+ * Share that folder with the service account `client_email` as Viewer.
+ */
+export function getGoogleDriveFolderIdFromEnv(): string | undefined {
+  const upper = process.env.GOOGLE_DRIVE_FOLDER_ID?.trim();
+  const lower = process.env.google_drive_folder_id?.trim();
+  const v = upper || lower;
+  return v ? v : undefined;
+}
+
+/**
+ * Lists workbook files whose name contains {@link DRIVE_PL_FILENAME_MARKER}.
+ *
+ * **Requires** {@link getGoogleDriveFolderIdFromEnv} to be set: lists direct
+ * children of that folder only. Without a folder ID, returns an empty array
+ * (no Drive calls, no `sharedWithMe` fallback).
+ *
+ * Paginates when listing; never throws solely for “no folder”.
+ */
+export async function listSharedPlSpreadsheetFileRefs(): Promise<DriveFileRef[]> {
+  const folderId = getGoogleDriveFolderIdFromEnv();
+  if (!folderId) return [];
+
+  const drive = getDriveClient();
+  const marker = driveQueryLiteral(DRIVE_PL_FILENAME_MARKER);
+  const q = `'${driveQueryLiteral(folderId)}' in parents and trashed = false and name contains '${marker}'`;
+  return listDriveFilesByQuery(drive, q);
 }
 
 /** Test-only: clear the singleton between cases. */

--- a/backend/src/lib/spreadsheet-revenue.ts
+++ b/backend/src/lib/spreadsheet-revenue.ts
@@ -24,7 +24,7 @@
  *
  * Never throws on failures → warns/logs → empty Map → callers render zeros.
  *
- * **Drive file:** Names contain `損益計算資料` (cf. PM / shared folder). If `Location.spreadsheetId` is empty, list `sharedWithMe` files matching that marker + **`Location.name`** + **`yearMonth`**, cache ~5 min. Default sheet: **`売上明細`** then **`車両別損益`** when both exist.
+ * **Drive file:** Names contain `損益計算資料`. Folder ID (`GOOGLE_DRIVE_FOLDER_ID` or `google_drive_folder_id`) is required for auto-discovery (direct children); no folder → no Drive list fallback. If `Location.spreadsheetId` is empty, match by marker + **`Location.name`** + **`yearMonth`**, cache ~5 min. Default sheet: **`売上明細`** then **`車両別損益`** when both exist.
  */
 
 import readXlsxFile, { readSheetNames } from "read-excel-file/node";


### PR DESCRIPTION
## Summary

Closes TeckVeho/Izumi_Issue-Requests-Repo#1152

Spreadsheet revenue auto-discovery now lists only direct children of a configured Google Drive folder. The previous `sharedWithMe` listing is removed when no folder id is set (returns an empty list; no Drive API calls).

## Environment

Set **one** of:
- `GOOGLE_DRIVE_FOLDER_ID`

The shared folder must grant the service account Viewer access. If neither is set, locations without `Location.spreadsheetId` cannot auto-resolve workbooks.

Explicit `Location.spreadsheetId` is unchanged: download still uses that file id directly.

## Tests

- `backend`: `npx vitest run src/lib/google-drive-client.test.ts`

## Files

- `backend/src/lib/google-drive-client.ts` — folder-scoped list, require env
- `backend/src/lib/google-drive-client.test.ts`
- `backend/.env.example`
- `backend/src/lib/spreadsheet-revenue.ts` — module doc only


Made with [Cursor](https://cursor.com)