### PR TITLE
feat(#1164): Read spreadsheet revenue from DB snapshots

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "googleapis": "^171.4.0",
         "jsonwebtoken": "^9.0.3",
         "multer": "^1.4.5-lts.1",
+        "node-cron": "^4.2.1",
         "read-excel-file": "^5.8.8",
         "zod": "^3.23.8"
       },
@@ -27,6 +28,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^1.4.11",
         "@types/node": "^20",
+        "@types/node-cron": "^3.0.11",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
         "supertest": "^7.0.0",
@@ -1093,6 +1095,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.15.0",
@@ -2673,6 +2682,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-domexception": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "googleapis": "^171.4.0",
     "jsonwebtoken": "^9.0.3",
     "multer": "^1.4.5-lts.1",
+    "node-cron": "^4.2.1",
     "read-excel-file": "^5.8.8",
     "zod": "^3.23.8"
   },
@@ -36,6 +37,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^1.4.11",
     "@types/node": "^20",
+    "@types/node-cron": "^3.0.11",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",
     "supertest": "^7.0.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,12 @@
 import { createApp } from "./app.js";
+import { startSpreadsheetRevenueScheduler } from "./lib/scheduler.js";
 
 const app = createApp();
 const PORT = process.env.PORT ?? 4000;
 
 app.listen(PORT, () => {
   console.log(`Backend server running at http://localhost:${PORT}`);
+
+  // スプレッドシート売上の定期同期スケジューラを起動
+  startSpreadsheetRevenueScheduler();
 });

--- a/backend/src/lib/scheduler.ts
+++ b/backend/src/lib/scheduler.ts
@@ -1,0 +1,209 @@
+/**
+ * Scheduled sync for spreadsheet revenue data.
+ *
+ * Downloads and parses P&L workbooks from Google Drive,
+ * then persists revenue data into DB snapshots (DriveSpreadsheetRevenueLine).
+ *
+ * Dashboard and income statement read from DB snapshots only,
+ * so this scheduler (or manual sync) is needed to keep snapshots up to date.
+ */
+
+import cron from "node-cron";
+import { prisma } from "./prisma.js";
+import {
+  defaultSpreadsheetRevenueSyncYearMonthsJst,
+  syncSpreadsheetRevenueForLocationYear,
+} from "./spreadsheet-revenue.js";
+import { logSpreadsheetRevenue } from "./spreadsheet-revenue-log.js";
+
+// ============================================================
+// [SCHEDULE CONFIGURATION] Change CRON_EXPRESSION below:
+//
+// Daily at 06:00 JST:           '0 6 * * *'     <-- default
+// Weekly on Monday 06:00 JST:   '0 6 * * 1'
+// Monthly on 1st at 06:00 JST:  '0 6 1 * *'
+// Twice daily 06:00 & 18:00:    '0 6,18 * * *'
+// Weekdays only at 06:00:       '0 6 * * 1-5'
+//
+// Cron format: minute hour day month weekday
+// ============================================================
+const CRON_EXPRESSION = "0 6 * * *"; // <-- change this
+const CRON_TIMEZONE = "Asia/Tokyo";
+
+/**
+ * Sync spreadsheet revenue for all locations (current month + previous month).
+ * Shared logic called by both the cron scheduler and the manual sync endpoint.
+ */
+export async function runSpreadsheetRevenueSync(
+  yearMonths?: string[]
+): Promise<{
+  yearMonths: string[];
+  totalLocations: number;
+  okCount: number;
+  failCount: number;
+  results: Array<{
+    locationId: string;
+    locationCode: string;
+    locationName: string;
+    yearMonth: string;
+    ok: boolean;
+    recordCount?: number;
+    driveFileId?: string;
+    sheetName?: string | null;
+    error?: string;
+  }>;
+}> {
+  const months =
+    yearMonths && yearMonths.length > 0
+      ? yearMonths
+      : defaultSpreadsheetRevenueSyncYearMonthsJst();
+
+  const locations = await prisma.location.findMany({
+    orderBy: { code: "asc" },
+    select: { id: true, code: true, name: true },
+  });
+
+  const results: Array<{
+    locationId: string;
+    locationCode: string;
+    locationName: string;
+    yearMonth: string;
+    ok: boolean;
+    recordCount?: number;
+    driveFileId?: string;
+    sheetName?: string | null;
+    error?: string;
+  }> = [];
+
+  let okCount = 0;
+  let failCount = 0;
+
+  for (const ym of months) {
+    for (const loc of locations) {
+      const r = await syncSpreadsheetRevenueForLocationYear(loc.id, ym);
+      if (r.ok) {
+        okCount++;
+        results.push({
+          locationId: loc.id,
+          locationCode: loc.code,
+          locationName: loc.name,
+          yearMonth: ym,
+          ok: true,
+          recordCount: r.recordCount,
+          driveFileId: r.driveFileId,
+          sheetName: r.sheetName,
+        });
+      } else {
+        failCount++;
+        results.push({
+          locationId: loc.id,
+          locationCode: loc.code,
+          locationName: loc.name,
+          yearMonth: ym,
+          ok: false,
+          error: r.error,
+          driveFileId: r.driveFileId,
+        });
+      }
+    }
+  }
+
+  // --- Structured sync summary logging ---
+  const successEntries = results.filter((r) => r.ok);
+  const failEntries = results.filter((r) => !r.ok);
+
+  const successSummary = successEntries
+    .map(
+      (r) =>
+        `  ✓ ${r.locationCode} (${r.locationName}) [${r.yearMonth}] → file=${r.driveFileId ?? "N/A"}, sheet=${r.sheetName ?? "N/A"}, records=${r.recordCount ?? 0}`
+    )
+    .join("\n");
+
+  const failSummary = failEntries
+    .map(
+      (r) =>
+        `  ✗ ${r.locationCode} (${r.locationName}) [${r.yearMonth}] → reason: ${r.error ?? "unknown"}`
+    )
+    .join("\n");
+
+  const logMessage = [
+    `[scheduler] spreadsheet-revenue sync complete: ${okCount} ok, ${failCount} skipped (${months.join(", ")})`,
+    successEntries.length > 0 ? `Synced locations:\n${successSummary}` : null,
+    failEntries.length > 0 ? `Skipped locations (no matching file/sheet):\n${failSummary}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  console.log(logMessage);
+
+  // Persist structured log to file
+  void logSpreadsheetRevenue("info", "sync summary", {
+    yearMonths: months.join(","),
+    totalLocations: locations.length,
+    okCount,
+    failCount,
+  });
+  for (const r of successEntries) {
+    void logSpreadsheetRevenue("info", "sync success", {
+      locationCode: r.locationCode,
+      locationName: r.locationName,
+      yearMonth: r.yearMonth,
+      driveFileId: r.driveFileId ?? null,
+      sheetName: r.sheetName ?? null,
+      recordCount: r.recordCount ?? 0,
+    });
+  }
+  for (const r of failEntries) {
+    void logSpreadsheetRevenue("warn", "sync skipped", {
+      locationCode: r.locationCode,
+      locationName: r.locationName,
+      yearMonth: r.yearMonth,
+      reason: r.error ?? "unknown",
+      driveFileId: r.driveFileId ?? null,
+    });
+  }
+
+  return {
+    yearMonths: months,
+    totalLocations: locations.length,
+    okCount,
+    failCount,
+    results,
+  };
+}
+
+let schedulerStarted = false;
+
+/**
+ * cron スケジューラを起動する（サーバー起動時に 1 回だけ呼び出す）。
+ */
+export function startSpreadsheetRevenueScheduler(): void {
+  if (schedulerStarted) return;
+  schedulerStarted = true;
+
+  console.log(
+    `[scheduler] spreadsheet-revenue cron registered: "${CRON_EXPRESSION}" (${CRON_TIMEZONE})`
+  );
+
+  cron.schedule(
+    CRON_EXPRESSION,
+    async () => {
+      const startedAt = new Date().toISOString();
+      console.log(
+        `[scheduler] spreadsheet-revenue sync started at ${startedAt}`
+      );
+
+      try {
+        const result = await runSpreadsheetRevenueSync();
+        console.log(
+          `[scheduler] spreadsheet-revenue sync completed: ${result.okCount} ok, ${result.failCount} failed (${result.yearMonths.join(", ")})`
+        );
+      } catch (err) {
+        console.error("[scheduler] spreadsheet-revenue sync error:", err);
+      }
+    },
+    {
+      timezone: CRON_TIMEZONE,
+    }
+  );
+}

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -15,13 +15,21 @@ import {
 } from "../lib/vehicle-costs.js";
 import { getPreviousYearMonth } from "../lib/salary-daily-proration.js";
 import { isLocationExpenseProrationAccount } from "../lib/location-expense-proration.js";
-import { getRevenueFromSpreadsheets } from "../lib/spreadsheet-revenue.js";
+import { requireRole, ROLES } from "../lib/auth.js";
+import { runSpreadsheetRevenueSync } from "../lib/scheduler.js";
 
 /** 手入力専用（スプレッドシート対象外・MonthlyRecord から取得） */
 const MANUAL_INPUT_ONLY_NAMES = ["その他", "不動産収入", "人材派遣収入"];
 
 export const dashboardRouter = Router();
 
+/**
+ * GET /summary — ダッシュボードサマリー
+ *
+ * 売上データは DB スナップショット（DriveSpreadsheetRevenueLine）から読み取る。
+ * Google Drive への real-time アクセスは行わない（高速化）。
+ * スナップショットが無い拠点/年月は売上 0 として表示する。
+ */
 dashboardRouter.get("/summary", async (req: Request, res: Response) => {
   const yearMonth = req.query.yearMonth as string;
 
@@ -32,7 +40,7 @@ dashboardRouter.get("/summary", async (req: Request, res: Response) => {
 
   const prevYearMonth = getPreviousYearMonth(yearMonth);
 
-  const [locations, vehicles, accountItems, records, prevMonthRecords, vehicleCosts, prevMonthVehicleCosts, locationExpenses, locationParams] =
+  const [locations, vehicles, accountItems, records, prevMonthRecords, vehicleCosts, prevMonthVehicleCosts, locationExpenses, locationParams, driveRevenueLines, syncMetas] =
     await Promise.all([
       prisma.location.findMany({ orderBy: { code: "asc" } }),
       prisma.vehicle.findMany({
@@ -72,6 +80,14 @@ dashboardRouter.get("/summary", async (req: Request, res: Response) => {
       prisma.locationCalculationParameter.findMany({
         where: { yearMonth: prevYearMonth },
       }),
+      // 売上データを DB スナップショットから直接取得（Google Drive を呼ばない）
+      prisma.driveSpreadsheetRevenueLine.findMany({
+        where: { yearMonth },
+      }),
+      // 同期メタデータ（最終同期日時取得用）
+      prisma.locationDriveSyncMeta.findMany({
+        where: { yearMonth },
+      }),
     ]);
 
   const revenueItemIds = new Set(
@@ -81,7 +97,7 @@ dashboardRouter.get("/summary", async (req: Request, res: Response) => {
     accountItems.filter((a) => a.category === EXPENSE_CATEGORY).map((a) => a.id)
   );
 
-  // 売上科目（手入力専用以外）は MonthlyRecord を参照せずスプレッドシートのみ
+  // 売上科目（手入力専用以外）は DB スナップショットから取得
   const revenueFromSpreadsheetIds = new Set(
     accountItems
       .filter(
@@ -199,23 +215,17 @@ dashboardRouter.get("/summary", async (req: Request, res: Response) => {
     }
   }
 
-  // 売上科目（手入力専用以外）は各拠点スプレッドシート参照のみ
-  const revenueAccountItemIds = Array.from(revenueFromSpreadsheetIds);
-  if (revenueAccountItemIds.length > 0) {
-    const locationIds = Array.from(new Set(vehicles.map((v) => v.locationId)));
-    for (const locId of locationIds) {
-      const locVehicleIds = vehicles
-        .filter((v) => v.locationId === locId)
-        .map((v) => v.id);
-      const spreadsheetRevenue = await getRevenueFromSpreadsheets({
-        locationId: locId,
-        yearMonth,
-        vehicleIds: locVehicleIds,
-        revenueAccountItemIds,
-      });
-      spreadsheetRevenue.forEach((amount, key) => {
-        recordMap.set(key, amount);
-      });
+  // 売上科目（手入力専用以外）は DB スナップショットから取得（Google Drive を呼ばない）
+  // スナップショットが無い場合は 0 として扱う
+  for (const line of driveRevenueLines) {
+    recordMap.set(`${line.vehicleId}-${line.accountItemId}`, Number(line.amount));
+  }
+
+  // 最終同期日時: syncMetas の中で最も新しい syncedAt
+  let lastSyncedAt: Date | null = null;
+  for (const meta of syncMetas) {
+    if (!lastSyncedAt || meta.syncedAt > lastSyncedAt) {
+      lastSyncedAt = meta.syncedAt;
     }
   }
 
@@ -258,6 +268,7 @@ dashboardRouter.get("/summary", async (req: Request, res: Response) => {
   res.json({
     yearMonth,
     lastUpdatedAt: lastUpdatedAt ? lastUpdatedAt.toISOString() : null,
+    lastSyncedAt: lastSyncedAt ? lastSyncedAt.toISOString() : null,
     summary: {
       totalNetRevenue,
       totalExpense,
@@ -268,3 +279,35 @@ dashboardRouter.get("/summary", async (req: Request, res: Response) => {
     locationSummaries,
   });
 });
+
+/**
+ * POST /sync — 手動でスプレッドシート売上同期を実行（MASTER 権限必須）
+ *
+ * リクエストボディ:
+ *   { yearMonth?: "YYYY-MM" }  — 省略時は当月＋前月を同期
+ */
+dashboardRouter.post(
+  "/sync",
+  requireRole(ROLES.MASTER),
+  async (req: Request, res: Response) => {
+    const { yearMonth } = req.body ?? {};
+
+    const yearMonths = yearMonth
+      ? [String(yearMonth).trim()]
+      : undefined; // undefined → defaultSpreadsheetRevenueSyncYearMonthsJst()
+
+    try {
+      const result = await runSpreadsheetRevenueSync(yearMonths);
+      res.json({
+        success: true,
+        ...result,
+      });
+    } catch (err) {
+      console.error("[dashboard/sync] error:", err);
+      res.status(500).json({
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+);

--- a/backend/src/routes/income-statement.ts
+++ b/backend/src/routes/income-statement.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/vehicle-costs.js";
 import { getPreviousYearMonth } from "../lib/salary-daily-proration.js";
 import { isLocationExpenseProrationAccount } from "../lib/location-expense-proration.js";
-import { getRevenueFromSpreadsheets } from "../lib/spreadsheet-revenue.js";
+
 /** 手入力専用（CSV/API一括登録不可）の勘定科目名 */
 const MANUAL_INPUT_ONLY_NAMES = ["その他", "不動産収入", "人材派遣収入"];
 
@@ -86,7 +86,7 @@ incomeStatementRouter.get("/", async (req: Request, res: Response) => {
   const vehicleIds = vehicles.map((v) => v.id);
   const prevYearMonth = getPreviousYearMonth(yearMonth);
 
-  const [records, prevMonthRecords, vehicleCosts, prevMonthVehicleCosts, locationExpenses, locationParams, accountItemsForCost] =
+  const [records, prevMonthRecords, vehicleCosts, prevMonthVehicleCosts, locationExpenses, locationParams, accountItemsForCost, driveRevenueLines] =
     await Promise.all([
       prisma.monthlyRecord.findMany({
         where: {
@@ -128,6 +128,13 @@ incomeStatementRouter.get("/", async (req: Request, res: Response) => {
       prisma.accountItem.findMany({
         where: accountItemEffectiveWhere(yearMonth),
         select: { id: true, code: true, category: true, name: true },
+      }),
+      // 売上データを DB スナップショットから直接取得（Google Drive を呼ばない）
+      prisma.driveSpreadsheetRevenueLine.findMany({
+        where: {
+          yearMonth,
+          locationId,
+        },
       }),
     ]);
 
@@ -237,18 +244,9 @@ incomeStatementRouter.get("/", async (req: Request, res: Response) => {
     }
   }
 
-  // 売上科目（手入力専用以外）は各拠点スプレッドシート参照のみ
-  const revenueAccountItemIds = Array.from(revenueFromSpreadsheetIds);
-  if (revenueAccountItemIds.length > 0) {
-    const spreadsheetRevenue = await getRevenueFromSpreadsheets({
-      locationId,
-      yearMonth,
-      vehicleIds: vehicles.map((v) => v.id),
-      revenueAccountItemIds,
-    });
-    spreadsheetRevenue.forEach((amount, key) => {
-      recordMap.set(key, amount);
-    });
+  // 売上科目（手入力専用以外）は DB スナップショットから取得（Google Drive を呼ばない）
+  for (const line of driveRevenueLines) {
+    recordMap.set(`${line.vehicleId}-${line.accountItemId}`, Number(line.amount));
   }
 
   res.json({
@@ -287,7 +285,7 @@ incomeStatementRouter.get("/export", async (req: Request, res: Response) => {
   const exportPrevYearMonth = getPreviousYearMonth(yearMonth);
 
   const locationIdsForExport = Array.from(new Set(vehicles.map((v) => v.locationId)));
-  const [accountItems, records, exportPrevMonthRecords, vehicleCosts, prevMonthVehicleCostsExport, locationExpensesForExport, locationParamsForExport] =
+  const [accountItems, records, exportPrevMonthRecords, vehicleCosts, prevMonthVehicleCostsExport, locationExpensesForExport, locationParamsForExport, exportDriveRevenueLines] =
     await Promise.all([
       prisma.accountItem.findMany({
         where: accountItemEffectiveWhere(yearMonth),
@@ -328,6 +326,13 @@ incomeStatementRouter.get("/export", async (req: Request, res: Response) => {
         where: {
           yearMonth: exportPrevYearMonth,
           locationId: { in: locationIdsForExport },
+        },
+      }),
+      // 売上データを DB スナップショットから直接取得（Google Drive を呼ばない）
+      prisma.driveSpreadsheetRevenueLine.findMany({
+        where: {
+          yearMonth,
+          ...(locationId ? { locationId } : { locationId: { in: locationIdsForExport } }),
         },
       }),
     ]);
@@ -433,24 +438,9 @@ incomeStatementRouter.get("/export", async (req: Request, res: Response) => {
     }
   }
 
-  // 売上科目（手入力専用以外）は各拠点スプレッドシート参照のみ
-  const exportRevenueAccountItemIds = Array.from(exportRevenueFromSpreadsheetIds);
-  if (exportRevenueAccountItemIds.length > 0) {
-    const locationIds = Array.from(new Set(vehicles.map((v) => v.locationId)));
-    for (const locId of locationIds) {
-      const locVehicleIds = vehicles
-        .filter((v) => v.locationId === locId)
-        .map((v) => v.id);
-      const spreadsheetRevenue = await getRevenueFromSpreadsheets({
-        locationId: locId,
-        yearMonth,
-        vehicleIds: locVehicleIds,
-        revenueAccountItemIds: exportRevenueAccountItemIds,
-      });
-      spreadsheetRevenue.forEach((amount, key) => {
-        recordMap.set(key, amount);
-      });
-    }
+  // 売上科目（手入力専用以外）は DB スナップショットから取得（Google Drive を呼ばない）
+  for (const line of exportDriveRevenueLines) {
+    recordMap.set(`${line.vehicleId}-${line.accountItemId}`, Number(line.amount));
   }
 
   const revenueIds = new Set(

--- a/src/app/daily-summary/page.tsx
+++ b/src/app/daily-summary/page.tsx
@@ -13,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useYearMonthStore, getYears, getMonths, getMaxMonth } from "@/stores/yearMonthStore";
 
 interface Location {
   id: string;
@@ -28,17 +29,7 @@ interface Vehicle {
   course?: { id: string; name: string; code: string } | null;
 }
 
-function getYearMonths(): string[] {
-  const months: string[] = [];
-  const now = new Date();
-  for (let i = -12; i <= 12; i++) {
-    const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
-    months.push(
-      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
-    );
-  }
-  return months.reverse();
-}
+
 
 function DailySummaryContent() {
   const searchParams = useSearchParams();
@@ -51,12 +42,33 @@ function DailySummaryContent() {
     Record<string, number>
   >({});
   const [daysInMonth, setDaysInMonth] = useState(31);
-  const [yearMonth, setYearMonth] = useState(() => {
+
+  // 年月は共有ストアを使用（ページ間で選択を保持）
+  const { year, month, yearMonth: storeYearMonth, setYear, setMonth, setYearMonth: setStoreYearMonth } = useYearMonthStore();
+  const [yearMonth, setYearMonthLocal] = useState(() => {
     const fromUrl = searchParams.get("yearMonth");
-    if (fromUrl) return fromUrl;
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    if (fromUrl) {
+      setStoreYearMonth(fromUrl);
+      return fromUrl;
+    }
+    return storeYearMonth;
   });
+  const setYearMonth = (ym: string) => {
+    setYearMonthLocal(ym);
+    setStoreYearMonth(ym);
+  };
+  const handleYearChange = (v: string) => {
+    const newYear = Number(v);
+    const max = getMaxMonth(newYear);
+    const clampedMonth = month > max ? max : month;
+    setYear(newYear);
+    setYearMonthLocal(`${newYear}-${String(clampedMonth).padStart(2, "0")}`);
+  };
+  const handleMonthChange = (v: string) => {
+    setMonth(Number(v));
+    setYearMonthLocal(`${year}-${String(v).padStart(2, "0")}`);
+  };
+
   const [locationId, setLocationId] = useState(() => {
     return searchParams.get("locationId") ?? "all";
   });
@@ -109,7 +121,7 @@ function DailySummaryContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [yearMonth, locationId]);
 
-  const yearMonths = getYearMonths();
+
 
   if (loading && vehicles.length === 0) {
     return <LoadingOverlay message="読み込み中" />;
@@ -126,18 +138,29 @@ function DailySummaryContent() {
       </div>
 
       <div className="flex flex-nowrap gap-5 items-center mb-6 overflow-x-auto">
-        <div className="flex items-center gap-2 shrink-0">
-          <span className="text-sm text-muted-foreground whitespace-nowrap">
-            年月
-          </span>
-          <Select value={yearMonth} onValueChange={setYearMonth}>
-            <SelectTrigger className="w-36">
+      <div className="flex items-center gap-2 shrink-0">
+          <span className="text-sm text-muted-foreground whitespace-nowrap">年</span>
+          <Select value={String(year)} onValueChange={handleYearChange}>
+            <SelectTrigger className="w-24">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {yearMonths.map((ym) => (
-                <SelectItem key={ym} value={ym}>
-                  {ym.replace("-", "年")}月
+              {getYears().map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y}年
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <span className="text-sm text-muted-foreground whitespace-nowrap">月</span>
+          <Select value={String(month)} onValueChange={handleMonthChange}>
+            <SelectTrigger className="w-20">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {getMonths(year).map((m) => (
+                <SelectItem key={m} value={String(m)}>
+                  {m}月
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import {
   Select,
@@ -18,8 +18,15 @@ import {
   Car,
   MapPin,
   ChevronRight,
+  RefreshCw,
 } from "lucide-react";
 import { LoadingOverlay } from "@/components/income-statement/LoadingOverlay";
+import {
+  useYearMonthStore,
+  getYears,
+  getMonths,
+} from "@/stores/yearMonthStore";
+import { useAuthStore, canManageMaster } from "@/stores/authStore";
 
 interface LocationSummary {
   locationId: string;
@@ -34,6 +41,7 @@ interface LocationSummary {
 interface DashboardData {
   yearMonth: string;
   lastUpdatedAt: string | null;
+  lastSyncedAt: string | null;
   summary: {
     totalNetRevenue: number;
     totalExpense: number;
@@ -44,47 +52,108 @@ interface DashboardData {
   locationSummaries: LocationSummary[];
 }
 
-function getYearMonths(): string[] {
-  const months: string[] = [];
-  const now = new Date();
-  for (let i = -12; i <= 12; i++) {
-    const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
-    months.push(
-      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
-    );
-  }
-  return months.reverse();
-}
-
 export default function DashboardPage() {
-  const [yearMonth, setYearMonth] = useState(() => {
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
-  });
+  const { year, month, yearMonth, setYear, setMonth } = useYearMonthStore();
+  const user = useAuthStore((s) => s.user);
+  const isMaster = user ? canManageMaster(user.role) : false;
+
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState<{
+    type: "success" | "info" | "error";
+    message: string;
+    details?: string[];
+  } | null>(null);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      try {
-        const res = await fetchApi(`/api/dashboard/summary?yearMonth=${yearMonth}`);
-        const json = await res.json();
-        if (!res.ok || !json.summary) {
-          setData(null);
-          return;
-        }
-        setData(json);
-      } catch {
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchApi(`/api/dashboard/summary?yearMonth=${yearMonth}`);
+      const json = await res.json();
+      if (!res.ok || !json.summary) {
         setData(null);
-      } finally {
-        setLoading(false);
+        return;
       }
-    };
-    fetchData();
+      setData(json);
+    } catch {
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
   }, [yearMonth]);
 
-  const yearMonths = getYearMonths();
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleSync = async () => {
+    setSyncing(true);
+    setSyncResult(null);
+    try {
+      const res = await fetchApi("/api/dashboard/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ yearMonth }),
+      });
+      const json = await res.json();
+      if (res.ok && json.success) {
+        const totalLocations = json.totalLocations ?? (json.okCount + json.failCount);
+        const message = `同期完了: ${totalLocations}拠点中 ${json.okCount}拠点のデータを同期しました` +
+          (json.failCount > 0 ? `（${json.failCount}拠点はファイル未検出のためスキップ）` : "");
+
+        // Build detail lines for synced locations
+        const details: string[] = [];
+        if (json.results && Array.isArray(json.results)) {
+          const synced = json.results.filter((r: { ok: boolean }) => r.ok);
+          const skipped = json.results.filter((r: { ok: boolean }) => !r.ok);
+
+          if (synced.length > 0) {
+            details.push("【同期済み】");
+            for (const r of synced) {
+              details.push(`  ✓ ${r.locationCode ?? ""} ${r.locationName ?? ""} — ${r.recordCount ?? 0}件`);
+            }
+          }
+          if (skipped.length > 0) {
+            details.push("【スキップ】");
+            for (const r of skipped) {
+              const reason = r.error?.includes("no spreadsheetId")
+                ? "対応ファイル未検出"
+                : r.error?.includes("no_matching_sheet_tab")
+                  ? "対応シート未検出"
+                  : r.error ?? "不明";
+              details.push(`  − ${r.locationCode ?? ""} ${r.locationName ?? ""} — ${reason}`);
+            }
+          }
+        }
+
+        setSyncResult({
+          type: json.failCount > 0 ? "info" : "success",
+          message,
+          details: details.length > 0 ? details : undefined,
+        });
+        // リロードしてデータを更新
+        await fetchData();
+      } else {
+        setSyncResult({
+          type: "error",
+          message: `同期失敗: ${json.error || "不明なエラー"}`,
+        });
+      }
+    } catch {
+      setSyncResult({
+        type: "error",
+        message: "同期に失敗しました。ネットワークを確認してください。",
+      });
+    } finally {
+      setSyncing(false);
+      // 10秒後にメッセージを消す（詳細あるため長めに）
+      setTimeout(() => setSyncResult(null), 10000);
+    }
+  };
+
+  const years = getYears();
+  const months = getMonths(year);
 
   if (loading && !data) {
     return <LoadingOverlay message="読み込み中" />;
@@ -96,15 +165,28 @@ export default function DashboardPage() {
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-3xl font-bold tracking-tight">ダッシュボード</h1>
           <div className="flex items-center gap-2 shrink-0">
-            <span className="text-sm text-muted-foreground whitespace-nowrap">年月</span>
-            <Select value={yearMonth} onValueChange={setYearMonth}>
-              <SelectTrigger className="w-36">
+            <span className="text-sm text-muted-foreground whitespace-nowrap">年</span>
+            <Select value={String(year)} onValueChange={(v) => setYear(Number(v))}>
+              <SelectTrigger className="w-24">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {yearMonths.map((ym) => (
-                  <SelectItem key={ym} value={ym}>
-                    {ym.replace("-", "年")}月
+                {years.map((y) => (
+                  <SelectItem key={y} value={String(y)}>
+                    {y}年
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span className="text-sm text-muted-foreground whitespace-nowrap">月</span>
+            <Select value={String(month)} onValueChange={(v) => setMonth(Number(v))}>
+              <SelectTrigger className="w-20">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {months.map((m) => (
+                  <SelectItem key={m} value={String(m)}>
+                    {m}月
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -125,37 +207,107 @@ export default function DashboardPage() {
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">ダッシュボード</h1>
-          {data?.lastUpdatedAt && (
-            <p className="text-xs text-muted-foreground mt-1">
-              最終更新:{" "}
-              {new Date(data.lastUpdatedAt).toLocaleString("ja-JP", {
-                year: "numeric",
-                month: "2-digit",
-                day: "2-digit",
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
-            </p>
-          )}
+          <div className="flex items-center gap-3 mt-1">
+            {data?.lastUpdatedAt && (
+              <p className="text-xs text-muted-foreground">
+                最終更新:{" "}
+                {new Date(data.lastUpdatedAt).toLocaleString("ja-JP", {
+                  year: "numeric",
+                  month: "2-digit",
+                  day: "2-digit",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </p>
+            )}
+            {data?.lastSyncedAt && (
+              <p className="text-xs text-muted-foreground">
+                最終同期:{" "}
+                {new Date(data.lastSyncedAt).toLocaleString("ja-JP", {
+                  year: "numeric",
+                  month: "2-digit",
+                  day: "2-digit",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </p>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          {/* 手動同期ボタン（MASTER 権限のみ表示） */}
+          {isMaster && (
+            <button
+              type="button"
+              onClick={handleSync}
+              disabled={syncing}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Google Drive からスプレッドシート売上データを同期"
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${syncing ? "animate-spin" : ""}`}
+              />
+              {syncing ? "同期中..." : "データ同期"}
+            </button>
+          )}
+
           <span className="text-sm text-muted-foreground whitespace-nowrap">
-            年月
+            年
           </span>
-          <Select value={yearMonth} onValueChange={setYearMonth}>
-            <SelectTrigger className="w-36">
+          <Select value={String(year)} onValueChange={(v) => setYear(Number(v))}>
+            <SelectTrigger className="w-24">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {yearMonths.map((ym) => (
-                <SelectItem key={ym} value={ym}>
-                  {ym.replace("-", "年")}月
+              {years.map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y}年
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            月
+          </span>
+          <Select value={String(month)} onValueChange={(v) => setMonth(Number(v))}>
+            <SelectTrigger className="w-20">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {months.map((m) => (
+                <SelectItem key={m} value={String(m)}>
+                  {m}月
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
       </div>
+
+      {/* 同期結果メッセージ */}
+      {syncResult && (
+        <div
+          className={`mb-4 px-4 py-3 text-sm border ${
+            syncResult.type === "error"
+              ? "border-destructive/50 bg-destructive/10 text-destructive"
+              : syncResult.type === "info"
+                ? "border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+                : "border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-400"
+          }`}
+        >
+          <div className="font-medium">{syncResult.message}</div>
+          {syncResult.details && syncResult.details.length > 0 && (
+            <details className="mt-2">
+              <summary className="cursor-pointer text-xs opacity-80 hover:opacity-100">
+                詳細を表示
+              </summary>
+              <pre className="mt-1 text-xs whitespace-pre-wrap leading-relaxed opacity-90">
+                {syncResult.details.join("\n")}
+              </pre>
+            </details>
+          )}
+        </div>
+      )}
 
       {data && (
         <>

--- a/src/app/income-statement/page.tsx
+++ b/src/app/income-statement/page.tsx
@@ -13,6 +13,7 @@ import { Download, History, Pencil, PencilOff } from "lucide-react";
 import { getCategoryLabel } from "@/lib/calc";
 import { fetchApi, getApiUrl } from "@/lib/api";
 import { useAuthStore, canEditPL } from "@/stores/authStore";
+import { useYearMonthStore } from "@/stores/yearMonthStore";
 
 /** Bump when cache shape/API contract changes so stale empty payloads are dropped */
 const CACHE_KEY_PREFIX = "income-statement:v2";
@@ -117,12 +118,24 @@ function IncomeStatementContent() {
   const [accountItems, setAccountItems] = useState<AccountItem[]>([]);
   const [records, setRecords] = useState<Record<string, number>>({});
   const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
-  const [yearMonth, setYearMonth] = useState(() => {
+
+  // 年月は共有ストアを使用（ページ間で選択を保持）
+  const { yearMonth: storeYearMonth, setYearMonth: setStoreYearMonth } = useYearMonthStore();
+  const [yearMonth, setYearMonthLocal] = useState(() => {
     const fromUrl = searchParams.get("yearMonth");
-    if (fromUrl) return fromUrl;
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    if (fromUrl) {
+      // URL パラメータがあればストアも更新
+      setStoreYearMonth(fromUrl);
+      return fromUrl;
+    }
+    return storeYearMonth;
   });
+  // yearMonth 変更時にストアも同期
+  const setYearMonth = (ym: string) => {
+    setYearMonthLocal(ym);
+    setStoreYearMonth(ym);
+  };
+
   const [locationId, setLocationId] = useState<string | null>(() => {
     return searchParams.get("locationId");
   });

--- a/src/components/income-statement/FilterBar.tsx
+++ b/src/components/income-statement/FilterBar.tsx
@@ -11,6 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import type { DisplayMode } from "./PLTable";
+import { getYears, getMonths, getMaxMonth, parseYearMonth } from "@/stores/yearMonthStore";
 
 interface FilterBarProps {
   yearMonth: string;
@@ -21,18 +22,6 @@ interface FilterBarProps {
   onDisplayModeChange: (value: DisplayMode) => void;
 }
 
-function getYearMonths(): string[] {
-  const months: string[] = [];
-  const now = new Date();
-  for (let i = -12; i <= 12; i++) {
-    const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
-    months.push(
-      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
-    );
-  }
-  return months.reverse();
-}
-
 export function FilterBar({
   yearMonth,
   searchQuery,
@@ -41,20 +30,47 @@ export function FilterBar({
   onSearchChange,
   onDisplayModeChange,
 }: FilterBarProps) {
-  const yearMonths = getYearMonths();
+  const years = getYears();
+  const { year, month } = parseYearMonth(yearMonth);
+  const months = getMonths(year);
+
+  const handleYearChange = (v: string) => {
+    const newYear = Number(v);
+    const max = getMaxMonth(newYear);
+    const clampedMonth = month > max ? max : month;
+    onYearMonthChange(`${newYear}-${String(clampedMonth).padStart(2, "0")}`);
+  };
+
+  const handleMonthChange = (v: string) => {
+    const newMonth = Number(v);
+    onYearMonthChange(`${year}-${String(newMonth).padStart(2, "0")}`);
+  };
 
   return (
     <div className="flex flex-nowrap gap-5 items-center mb-6 overflow-x-auto">
       <div className="flex items-center gap-2 shrink-0">
-        <span className="text-sm text-muted-foreground whitespace-nowrap">年月</span>
-        <Select value={yearMonth} onValueChange={onYearMonthChange}>
-          <SelectTrigger className="w-36">
+        <span className="text-sm text-muted-foreground whitespace-nowrap">年</span>
+        <Select value={String(year)} onValueChange={handleYearChange}>
+          <SelectTrigger className="w-24">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {yearMonths.map((ym) => (
-              <SelectItem key={ym} value={ym}>
-                {ym.replace("-", "年")}月
+            {years.map((y) => (
+              <SelectItem key={y} value={String(y)}>
+                {y}年
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span className="text-sm text-muted-foreground whitespace-nowrap">月</span>
+        <Select value={String(month)} onValueChange={handleMonthChange}>
+          <SelectTrigger className="w-20">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {months.map((m) => (
+              <SelectItem key={m} value={String(m)}>
+                {m}月
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -47,7 +47,7 @@ const masterSubMenu = [
   { href: "/arbitrary-insurance", label: "任意保険マスタ", icon: Shield, roles: "MASTER" as const },
   { href: "/location-calculation-parameters", label: "拠点別計算パラメータ", icon: Settings2, roles: "MASTER" as const },
   { href: "/locations", label: "拠点スプレッドシート設定", icon: Database, roles: "MASTER" as const },
-  { href: "/course-vehicle-mapping", label: "コース・車両マッピング", icon: MapPin, roles: null },
+  // { href: "/course-vehicle-mapping", label: "コース・車両マッピング", icon: MapPin, roles: null },
 ];
 
 export function Header() {

--- a/src/stores/yearMonthStore.ts
+++ b/src/stores/yearMonthStore.ts
@@ -1,0 +1,97 @@
+/**
+ * 年月の共有ストア — ダッシュボード・損益計算書など複数ページで年月選択を共有する。
+ * ページ遷移しても選択状態を保持する（zustand はメモリ内ストアのため SPA 遷移で維持される）。
+ */
+
+import { create } from "zustand";
+
+function currentYear(): number {
+  return new Date().getFullYear();
+}
+
+function currentMonth(): number {
+  return new Date().getMonth() + 1; // 1-indexed
+}
+
+/** 年の選択肢を生成（現在の年 以前 5年分） */
+export function getYears(): number[] {
+  const now = currentYear();
+  const years: number[] = [];
+  for (let y = now; y >= now - 4; y--) {
+    years.push(y);
+  }
+  return years;
+}
+
+/** 月の選択肢（1〜12）。選択年が今年の場合は最大 currentMonth + 1 まで */
+export function getMonths(selectedYear?: number): number[] {
+  const now = new Date();
+  const thisYear = now.getFullYear();
+  const thisMonth = now.getMonth() + 1; // 1-indexed
+
+  const maxMonth =
+    selectedYear !== undefined && selectedYear === thisYear
+      ? Math.min(thisMonth + 1, 12)
+      : 12;
+
+  const months: number[] = [];
+  for (let m = 1; m <= maxMonth; m++) {
+    months.push(m);
+  }
+  return months;
+}
+
+/** 選択年に対する最大月を返す */
+export function getMaxMonth(selectedYear: number): number {
+  const now = new Date();
+  const thisYear = now.getFullYear();
+  const thisMonth = now.getMonth() + 1;
+  return selectedYear === thisYear ? Math.min(thisMonth + 1, 12) : 12;
+}
+
+/** 年 + 月 → "YYYY-MM" */
+export function toYearMonth(year: number, month: number): string {
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+/** "YYYY-MM" → { year, month } */
+export function parseYearMonth(ym: string): { year: number; month: number } {
+  const [y, m] = ym.split("-").map(Number);
+  return { year: y, month: m };
+}
+
+interface YearMonthState {
+  year: number;
+  month: number;
+  /** "YYYY-MM" 形式の結合値（computed） */
+  yearMonth: string;
+  setYear: (year: number) => void;
+  setMonth: (month: number) => void;
+  /** URL パラメータ等からの一括設定 */
+  setYearMonth: (ym: string) => void;
+}
+
+export const useYearMonthStore = create<YearMonthState>((set) => ({
+  year: currentYear(),
+  month: currentMonth(),
+  yearMonth: toYearMonth(currentYear(), currentMonth()),
+  setYear: (year) =>
+    set((state) => {
+      const max = getMaxMonth(year);
+      const month = state.month > max ? max : state.month;
+      return {
+        year,
+        month,
+        yearMonth: toYearMonth(year, month),
+      };
+    }),
+  setMonth: (month) =>
+    set((state) => ({
+      month,
+      yearMonth: toYearMonth(state.year, month),
+    })),
+  setYearMonth: (ym: string) => {
+    const { year, month } = parseYearMonth(ym);
+    set({ year, month, yearMonth: toYearMonth(year, month) });
+  },
+}));


### PR DESCRIPTION
Closes TeckVeho/Izumi_Issue-Requests-Repo#1164

## Summary
- Dashboard và income statement đọc doanh thu từ snapshot DB (`DriveSpreadsheetRevenueLine`) thay vì gọi Google Drive realtime khi load trang.
- Thêm scheduler (node-cron, 06:00 JST hàng ngày) để đồng bộ P&L từ Drive vào DB; có thể đồng bộ thủ công qua `POST /dashboard/sync` (MASTER).
- API summary trả thêm `lastSyncedAt`; frontend: store năm/tháng dùng chung, UI sync/filter cập nhật theo luồng mới.

## Notes
- Nếu chưa có snapshot cho một cửa/period, doanh thu hiển thị 0 (đã ghi trong code backend).

Made with [Cursor](https://cursor.com)