### PR TITLE
feat(locations): Drive folder spreadsheet list API and location UI (#57)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,3 +33,9 @@ CORS_ORIGIN="http://localhost:3000"
 # If unset: no folder listing → Locations without spreadsheetId cannot auto-resolve.
 # GOOGLE_DRIVE_FOLDER_ID=
 # google_drive_folder_id=
+#
+# Location spreadsheet settings UI (Issue #57): users enter a Drive folder URL/ID
+# and call GET /api/drive/spreadsheets?folderId= to list native Google Spreadsheets
+# in that folder. Share the target folder with the service account client_email as
+# Viewer (same as above). The folder ID is not stored in the DB — only each location's
+# spreadsheetId (file ID) is saved via PATCH /api/locations/:id.

--- a/backend/scripts/drive-folder-smoke.ts
+++ b/backend/scripts/drive-folder-smoke.ts
@@ -15,6 +15,7 @@
  * Run from backend/:
  *   npx tsx --env-file=.env scripts/drive-folder-smoke.ts
  *   npx tsx --env-file=.env scripts/drive-folder-smoke.ts <OTHER_FOLDER_ID>
+ *   npx tsx --env-file=.env scripts/drive-folder-smoke.ts --spreadsheets-only <FOLDER_ID>
  *   SMOKE_DRIVE_FOLDER_ID=<id> npx tsx --env-file=.env scripts/drive-folder-smoke.ts
  *
  * If `--env-file` is unsupported, export GOOGLE_SERVICE_ACCOUNT_JSON in the shell first.
@@ -22,16 +23,36 @@
 import {
   downloadDriveFileAsXlsxBuffer,
   getDriveClient,
+  listSpreadsheetsInFolder,
 } from "../src/lib/google-drive-client.js";
 
 /** Test folder used by the smoke script. Override with CLI arg or SMOKE_DRIVE_FOLDER_ID. */
 const DEFAULT_FOLDER = "1FFhlsFB90y-PrCVQCr3-ROLi5bcinTt5";
 
-async function main(): Promise<void> {
+function parseArgs(argv: string[]): { folderId: string; spreadsheetsOnly: boolean } {
+  const spreadsheetsOnly = argv.includes("--spreadsheets-only");
+  const positional = argv.filter((arg) => arg !== "--spreadsheets-only");
   const folderId =
     process.env.SMOKE_DRIVE_FOLDER_ID?.trim() ||
-    process.argv[2]?.trim() ||
+    positional[2]?.trim() ||
     DEFAULT_FOLDER;
+  return { folderId, spreadsheetsOnly };
+}
+
+async function main(): Promise<void> {
+  const { folderId, spreadsheetsOnly } = parseArgs(process.argv);
+
+  if (spreadsheetsOnly) {
+    const spreadsheets = await listSpreadsheetsInFolder(folderId);
+    console.log(
+      `Found ${spreadsheets.length} spreadsheet(s) in folder ${folderId}:\n`
+    );
+    for (const s of spreadsheets) {
+      console.log(`- ${s.name}\n  id=${s.id}`);
+    }
+    return;
+  }
+
   const drive = getDriveClient();
 
   const list = await drive.files.list({

--- a/backend/src/lib/google-drive-client.test.ts
+++ b/backend/src/lib/google-drive-client.test.ts
@@ -40,6 +40,7 @@ import {
   getDriveClient,
   getGoogleDriveFolderIdFromEnv,
   listSharedPlSpreadsheetFileRefs,
+  listSpreadsheetsInFolder,
   MIME_GOOGLE_SHEETS,
   MIME_XLSX,
   resetGoogleDriveClientForTests,
@@ -320,6 +321,92 @@ describe("listSharedPlSpreadsheetFileRefs", () => {
       pageToken: undefined,
       supportsAllDrives: true,
       includeItemsFromAllDrives: true,
+    });
+  });
+});
+
+describe("listSpreadsheetsInFolder", () => {
+  beforeEach(() => {
+    resetGoogleDriveClientForTests();
+    vi.clearAllMocks();
+    process.env.GOOGLE_SERVICE_ACCOUNT_JSON = minimalServiceAccountJson;
+    clearDriveFolderEnv();
+  });
+
+  afterEach(() => {
+    resetGoogleDriveClientForTests();
+    if (originalEnv === undefined) {
+      delete process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+    } else {
+      process.env.GOOGLE_SERVICE_ACCOUNT_JSON = originalEnv;
+    }
+    restoreDriveFolderEnv();
+  });
+
+  it("throws when folderId is empty", async () => {
+    await expect(listSpreadsheetsInFolder("  ")).rejects.toThrow(
+      "[google-drive] listSpreadsheetsInFolder: empty folderId"
+    );
+    expect(filesListMock).not.toHaveBeenCalled();
+  });
+
+  it("queries direct children with native Sheets and xlsx mimeType filter", async () => {
+    filesListMock.mockResolvedValueOnce({
+      data: {
+        files: [{ id: "s2", name: "B sheet" }, { id: "s1", name: "A sheet" }],
+        nextPageToken: null,
+      },
+    });
+
+    const refs = await listSpreadsheetsInFolder("folderXYZ");
+
+    expect(refs).toEqual([
+      { id: "s1", name: "A sheet" },
+      { id: "s2", name: "B sheet" },
+    ]);
+    expect(filesListMock).toHaveBeenCalledWith({
+      q: `'folderXYZ' in parents and trashed = false and (mimeType = '${MIME_GOOGLE_SHEETS}' or mimeType = '${MIME_XLSX}')`,
+      fields: "nextPageToken, files(id, name)",
+      pageSize: 100,
+      pageToken: undefined,
+      supportsAllDrives: true,
+      includeItemsFromAllDrives: true,
+    });
+  });
+
+  it("paginates across multiple pages", async () => {
+    filesListMock
+      .mockResolvedValueOnce({
+        data: {
+          files: [{ id: "p1", name: "Page 1" }],
+          nextPageToken: "token-2",
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          files: [{ id: "p2", name: "Page 2" }],
+          nextPageToken: null,
+        },
+      });
+
+    const refs = await listSpreadsheetsInFolder("folderPaginated");
+
+    expect(refs).toEqual([
+      { id: "p1", name: "Page 1" },
+      { id: "p2", name: "Page 2" },
+    ]);
+    expect(filesListMock).toHaveBeenCalledTimes(2);
+    expect(filesListMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ pageToken: "token-2" })
+    );
+  });
+
+  it("propagates Drive API errors", async () => {
+    filesListMock.mockRejectedValueOnce(Object.assign(new Error("forbidden"), { code: 403 }));
+
+    await expect(listSpreadsheetsInFolder("folderDenied")).rejects.toMatchObject({
+      code: 403,
     });
   });
 });

--- a/backend/src/lib/google-drive-client.ts
+++ b/backend/src/lib/google-drive-client.ts
@@ -172,6 +172,26 @@ export async function listSharedPlSpreadsheetFileRefs(): Promise<DriveFileRef[]>
   return listDriveFilesByQuery(drive, q);
 }
 
+/**
+ * Lists spreadsheet files that are direct children of `folderId`:
+ * native Google Sheets and uploaded `.xlsx` (both supported by
+ * {@link downloadDriveFileAsXlsxBuffer}). Results are sorted by name ascending.
+ */
+export async function listSpreadsheetsInFolder(
+  folderId: string
+): Promise<DriveFileRef[]> {
+  if (!folderId?.trim()) {
+    throw new Error("[google-drive] listSpreadsheetsInFolder: empty folderId");
+  }
+
+  const drive = getDriveClient();
+  const parent = driveQueryLiteral(folderId.trim());
+  const q = `'${parent}' in parents and trashed = false and (mimeType = '${MIME_GOOGLE_SHEETS}' or mimeType = '${MIME_XLSX}')`;
+  const refs = await listDriveFilesByQuery(drive, q);
+  refs.sort((a, b) => a.name.localeCompare(b.name, "ja"));
+  return refs;
+}
+
 /** Test-only: clear the singleton between cases. */
 export function resetGoogleDriveClientForTests(): void {
   driveClient = null;

--- a/backend/src/routes/drive.test.ts
+++ b/backend/src/routes/drive.test.ts
@@ -1,0 +1,155 @@
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "dev-secret-change-in-production";
+
+function signToken(role: string, userId: string) {
+  return jwt.sign(
+    { userId, email: `${userId}@test.local`, role },
+    JWT_SECRET,
+    { expiresIn: "7d" }
+  );
+}
+
+const { prismaMock, listSpreadsheetsInFolderMock } = vi.hoisted(() => ({
+  prismaMock: {
+    user: { findUnique: vi.fn() },
+  },
+  listSpreadsheetsInFolderMock: vi.fn(),
+}));
+
+vi.mock("../lib/prisma.js", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("../lib/google-drive-client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/google-drive-client.js")>();
+  return {
+    ...actual,
+    listSpreadsheetsInFolder: listSpreadsheetsInFolderMock,
+  };
+});
+
+import { createApp } from "../app.js";
+
+const app = createApp();
+
+function masterToken() {
+  return signToken("DX", "u1");
+}
+
+describe("GET /api/drive/spreadsheets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "u1",
+      email: "u1@test.local",
+      name: "Test",
+      role: "DX",
+    });
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await request(app).get("/api/drive/spreadsheets?folderId=abc");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when role is not MASTER", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "u2",
+      email: "u2@test.local",
+      name: "Crew",
+      role: "CREW",
+    });
+    const token = signToken("CREW", "u2");
+    const res = await request(app)
+      .get("/api/drive/spreadsheets?folderId=abc")
+      .set("Cookie", `auth-token=${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when folderId is missing", async () => {
+    const token = masterToken();
+    const res = await request(app)
+      .get("/api/drive/spreadsheets")
+      .set("Cookie", `auth-token=${token}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "folderId is required" });
+    expect(listSpreadsheetsInFolderMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with spreadsheets on success", async () => {
+    listSpreadsheetsInFolderMock.mockResolvedValueOnce([
+      { id: "sheet-1", name: "Alpha" },
+      { id: "sheet-2", name: "Beta" },
+    ]);
+    const token = masterToken();
+    const res = await request(app)
+      .get("/api/drive/spreadsheets?folderId=folder123")
+      .set("Cookie", `auth-token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      spreadsheets: [
+        { id: "sheet-1", name: "Alpha" },
+        { id: "sheet-2", name: "Beta" },
+      ],
+    });
+    expect(listSpreadsheetsInFolderMock).toHaveBeenCalledWith("folder123");
+  });
+
+  it("returns 503 when service account is not configured", async () => {
+    listSpreadsheetsInFolderMock.mockRejectedValueOnce(
+      new Error("[google-drive] GOOGLE_SERVICE_ACCOUNT_JSON is not set")
+    );
+    const token = masterToken();
+    const res = await request(app)
+      .get("/api/drive/spreadsheets?folderId=folder123")
+      .set("Cookie", `auth-token=${token}`);
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      error: "サービスアカウントが設定されていません",
+    });
+  });
+
+  it("returns 403 when Drive denies access", async () => {
+    listSpreadsheetsInFolderMock.mockRejectedValueOnce(
+      Object.assign(new Error("Insufficient permissions"), { code: 403 })
+    );
+    const token = masterToken();
+    const res = await request(app)
+      .get("/api/drive/spreadsheets?folderId=folder123")
+      .set("Cookie", `auth-token=${token}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      error: "フォルダがサービスアカウントと共有されていない可能性があります",
+    });
+  });
+
+  it("returns 404 when folder is not found", async () => {
+    listSpreadsheetsInFolderMock.mockRejectedValueOnce(
+      Object.assign(new Error("File not found"), { code: 404 })
+    );
+    const token = masterToken();
+    const res = await request(app)
+      .get("/api/drive/spreadsheets?folderId=missing")
+      .set("Cookie", `auth-token=${token}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: "フォルダが見つかりません" });
+  });
+
+  it("returns 502 for other Drive errors", async () => {
+    listSpreadsheetsInFolderMock.mockRejectedValueOnce(new Error("quota exceeded"));
+    const token = masterToken();
+    const res = await request(app)
+      .get("/api/drive/spreadsheets?folderId=folder123")
+      .set("Cookie", `auth-token=${token}`);
+
+    expect(res.status).toBe(502);
+    expect(res.body).toMatchObject({ error: "Drive API の取得に失敗しました" });
+  });
+});

--- a/backend/src/routes/drive.ts
+++ b/backend/src/routes/drive.ts
@@ -1,0 +1,57 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { listSpreadsheetsInFolder } from "../lib/google-drive-client.js";
+
+const spreadsheetsQuerySchema = z.object({
+  folderId: z.string().trim().min(1, "folderId is required"),
+});
+
+function getGoogleApiStatus(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const e = err as { code?: unknown; response?: { status?: unknown } };
+  if (typeof e.code === "number") return e.code;
+  if (typeof e.response?.status === "number") return e.response.status;
+  return undefined;
+}
+
+function mapDriveSpreadsheetsError(err: unknown): { status: number; error: string } {
+  const message = err instanceof Error ? err.message : String(err);
+  if (
+    message.includes("GOOGLE_SERVICE_ACCOUNT_JSON is not set") ||
+    message.includes("[google-drive] GOOGLE_SERVICE_ACCOUNT_JSON")
+  ) {
+    return { status: 503, error: "サービスアカウントが設定されていません" };
+  }
+
+  const apiStatus = getGoogleApiStatus(err);
+  if (apiStatus === 403) {
+    return {
+      status: 403,
+      error: "フォルダがサービスアカウントと共有されていない可能性があります",
+    };
+  }
+  if (apiStatus === 404) {
+    return { status: 404, error: "フォルダが見つかりません" };
+  }
+
+  return { status: 502, error: "Drive API の取得に失敗しました" };
+}
+
+export const driveRouter = Router();
+
+driveRouter.get("/spreadsheets", async (req: Request, res: Response) => {
+  const parsed = spreadsheetsQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: "folderId is required" });
+    return;
+  }
+
+  try {
+    const spreadsheets = await listSpreadsheetsInFolder(parsed.data.folderId);
+    res.json({ spreadsheets });
+  } catch (err) {
+    console.error("[drive/spreadsheets]", err);
+    const mapped = mapDriveSpreadsheetsError(err);
+    res.status(mapped.status).json({ error: mapped.error });
+  }
+});

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -21,6 +21,7 @@ import { coursesRouter } from "./courses.js";
 import { usersRouter } from "./users.js";
 import { syncLogsRouter } from "./sync-logs.js";
 import { spreadsheetRevenueRouter } from "./spreadsheet-revenue.js";
+import { driveRouter } from "./drive.js";
 
 export const apiRouter = Router();
 
@@ -51,4 +52,5 @@ apiRouter.use("/locations", locationsRouter);
 apiRouter.use("/import", requireRole(ROLES.EDIT_PL), importRouter);
 apiRouter.use("/courses", coursesRouter); // 権限チェックは courses 内で実施
 apiRouter.use("/spreadsheet-revenue", requireRole(ROLES.MASTER), spreadsheetRevenueRouter);
+apiRouter.use("/drive", requireRole(ROLES.MASTER), driveRouter);
 apiRouter.use("/sync-logs", syncLogsRouter);

--- a/docs/issues/vehicle-pl-system/57/issue.md
+++ b/docs/issues/vehicle-pl-system/57/issue.md
@@ -1,0 +1,126 @@
+# Issue #57
+
+## Context / Codebase Paths (from pre-questions)
+
+```yaml
+repository: TeckVeho/vehicle-pl-system
+repo: vehicle-pl-system
+issue_url: https://github.com/TeckVeho/vehicle-pl-system/issues/57
+github_project_v2_id: PVT_kwDOCjwUv84Ajq0M
+github_project_title: Izumi_Issue
+workspace_root: .
+frontend_path: .
+backend_path: ./backend
+migrations_path: ./backend/prisma/migrations
+api_docs_path:
+tests_path: ./backend/src
+```
+
+## Metadata
+
+| Field | Value |
+|--------|--------|
+| **Title** | feat: 拠点スプレッドシート設定でフォルダ指定からスプレッドシート一覧を自動取得する |
+| **State** | OPEN |
+| **URL** | https://github.com/TeckVeho/vehicle-pl-system/issues/57 |
+| **Created** | 2026-05-20T09:14:59Z |
+| **Updated** | 2026-05-21T05:13:16Z |
+| **Assignees** | tungnt183855 |
+| **Labels** | backend, frontend, middle priority |
+
+## Body
+
+### Description
+
+#### 日本語
+
+「拠点スプレッドシート設定」画面において、拠点ごとに Spreadsheet の URL／ID を手入力する運用を見直し、**Google Drive のフォルダ（URL またはフォルダ ID）だけを入力**すれば、そのフォルダ直下（または運用で定める範囲）に存在する **Google スプレッドシートの一覧（ファイル名・ID）を自動取得**し、拠点との紐付けに利用できるようにする。
+
+#### Tiếng Việt
+
+Trên màn hình cấu hình spreadsheet theo cơ sở, thay đổi để không cần dán URL/ID Sheets từng cơ sở như hiện tại; người dùng chỉ cần nhập **thư mục Google Drive (URL hoặc folder ID)** thì hệ thống **tự đọc danh sách Google Spreadsheet trong thư mục** (tên file, ID) để phục việc gán cho từng cơ sở.
+
+### Requirements
+
+#### 日本語
+
+- 画面上から **フォルダを指定**（共有ドライブ含む運用がある場合は仕様として明記）し、「一覧取得」等の操作で **スプレッドシートのみ**を列挙できること。
+- 取得結果を **現在の拠点テーブル**と組み合わせ、ユーザーが **どのファイルをどの拠点に紐付けるか**を設定できる UI にすること（**ファイル名のみの自動マッピング**を行う場合は、命名規約・取り込み順・競合時の扱いを要件で定義）。
+- 既存の保存 API（`/api/locations/:id` の `spreadsheetId`）との **互換を維持**し、最終的に保存される値は従来どおり Sheets の **ファイル ID** とすること。
+- サービスアカウント連携・権限エラー時は **利用者が原因を把握できるエラー表示**になること（既存の `drive.readonly`・フォルダ共有前提はドキュメント化）。
+- マスタ権限・画面アクセスは現行仕様と同等とする。
+
+#### Tiếng Việt
+
+- Người dùng chọn **thư mục** trên UI và có thể liệt kê **chỉ Google Spreadsheet** trong phạm vi đã thống nhất.
+- Kết hợp với bảng cơ sở hiện có để **gán file nào cho cơ sở nào**; nếu **tự map theo tên file** thì quy ước đặt tên, thứ tự, trùng tên phải được quy định.
+- **Tương thích** API lưu hiện tại (`spreadsheetId` là file ID).
+- Lỗi quyền / SA phải hiển thị rõ cho người dùng; ghi chú về share folder với service account.
+- Quyền MASTER / truy cập màn hình giữ như hiện tại.
+
+### Acceptance Criteria
+
+#### 日本語
+
+- [ ] フォルダ指定のみ（＋取得操作）で、対象フォルダ内の **スプレッドシート一覧**（少なくともファイル名と ID）が画面に表示される。
+- [ ] 取得した一覧を用いて、各拠点の `spreadsheetId` を設定・保存でき、既存の売上取り込み等と **引き続き連携できる**。
+- [ ] Drive API／認証設定が不正なとき、**適切なエラー**になる（開発者がログで追える程度の情報）。
+- [ ] アシストのみで **完全自動だけ**とする場合、**命名規約と例外時の手動変更**が受け入れ条件に織り込まれている。
+- [ ] ヘルプ文言が「フォルダと共有」の前提を踏まえ、**サービスアカウントへの共有**など既存運用と矛盾しない。
+
+#### Tiếng Việt
+
+- [ ] Chỉ định thư mục (+ thao tác tải) hiển thị **danh sách Spreadsheet** (tối thiểu tên + ID).
+- [ ] Gán và lưu `spreadsheetId` từng cơ sở, **tích hợp cũ vẫn chạy**.
+- [ ] Lỗi API/auth hiển thị hợp lý và có thể trace.
+- [ ] Nếu chỉ auto mapping theo tên: có quy ước và xử lý chỉnh tay khi lệch.
+- [ ] Copy hướng dẫn phù hợp với **share folder cho service account**.
+
+### Technical Context
+
+- **画面:** `src/app/locations/page.tsx` — 見出し「拠点スプレッドシート設定」。現状は各行で URL または Sheets ID を `extractSheetId` して `PATCH /api/locations/:id`。
+- **API:** `backend/src/routes/locations.ts` — `PATCH` で `spreadsheetId` を更新。**フォルダ内一覧用の GET**（または既存パスへの拡張）を新設する想定。
+- **Drive:** `backend/src/lib/google-drive-client.ts` — サービスアカウント・`drive.readonly`。`files.list` で `mimeType`/親フォルダを絞り、スプレッドシートだけ返す関数を追加する選択肢。**フォルダ ID の抽出**（URL 入力対応）はフロントまたは共通ユーティリティで統一してよい。
+- **検証:** `backend/scripts/drive-folder-smoke.ts` など既存 Drive 検証がある場合は流用。
+
+### Constraints
+
+#### 日本語
+
+- 共有ドライブ（Shared drive）対応が必要かどうかは実装前に確認し、必要なら `supportsAllDrives` 等の既存実装パターンに合わせる。
+- 「フォルダ内の全自動マッピング」は **運用ガイドラインなしには行わず**、少なくとも初版はドロップダウン等での **人的確認が可能な UI** とする前提を推奨（自動マッチはオプション扱いでもよい）。
+
+#### Tiếng Việt
+
+- Xác nhận Shared drive và tham khảo pattern API hiện có.
+- Không chỉ auto map hoàn toàn nếu chưa có quy ước; nên có UI chọn/xác nhận ở bản đầu.
+
+### Dependencies
+
+#### 日本語
+
+- 既存の Google サービスアカウント設定・環境変数 (`GOOGLE_SERVICE_ACCOUNT_JSON`)、および対象フォルダの共有設定が整っていることが前提。
+- （任意）インフラ側で Drive API の割り当て・クォータに問題がないこと。
+
+#### Tiếng Việt
+
+- Cấu hình service account và quyền share thư mục phải sẵn sàng.
+
+## Implementation checklist
+
+- [ ] **Backend / Drive client**: Add `listSpreadsheetsInFolder(folderId)` in `backend/src/lib/google-drive-client.ts` using `files.list` with `mimeType` filter and parent folder; handle Shared drive via `supportsAllDrives` if required.
+- [ ] **Backend / API**: New GET endpoint (e.g. `/api/drive/folders/:folderId/spreadsheets` or query-param variant) returning `{ id, name }[]`; user-friendly errors for auth/permission failures.
+- [ ] **Frontend / folder input**: Folder URL or ID input +「一覧取得」action on `src/app/locations/page.tsx`; extract folder ID from URL (shared utility).
+- [ ] **Frontend / mapping UI**: Display fetched spreadsheets; per-location dropdown (or similar) for manual assignment; optional filename-based auto-suggest with clear conflict handling.
+- [ ] **Frontend / save flow**: Keep existing `PATCH /api/locations/:id` with `spreadsheetId` (file ID only); no breaking changes to revenue import integration.
+- [ ] **Help copy**: Update help text for folder sharing with service account (`client_email` as Viewer).
+- [ ] **Tests**: Add backend tests under `./backend/src` for Drive list helper and new route (mock Drive client).
+- [ ] **Smoke / manual**: Reuse or extend `backend/scripts/drive-folder-smoke.ts` if present for manual verification.
+
+## Notes / review
+
+- **Project V2**: Single project detected — `Izumi_Issue` (`PVT_kwDOCjwUv84Ajq0M`) for `/breakdown` child issue assignment.
+- **Frontend layout**: Next.js app at repo root (`frontend_path: .`); pages under `src/app/`.
+- **OpenAPI**: No `openapi.yaml` / swagger artifact detected; leave `api_docs_path` empty.
+- **Current UI**: Locations page uses per-row manual URL/ID input with `extractSheetId`; MASTER role required via `canManageMaster`.
+- **Recommended v1 scope**: Manual dropdown assignment from fetched list; auto-match by filename as optional enhancement only if naming convention is documented.

--- a/docs/issues/vehicle-pl-system/57/plan.md
+++ b/docs/issues/vehicle-pl-system/57/plan.md
@@ -1,0 +1,343 @@
+# Issue #57: feat: 拠点スプレッドシート設定でフォルダ指定からスプレッドシート一覧を自動取得する - Implementation Plan
+
+## 概要 (Overview)
+
+[Issue #57](https://github.com/TeckVeho/vehicle-pl-system/issues/57) は **「拠点スプレッドシート設定」** 画面（`/locations`）の運用改善である。
+
+**現状:** 拠点ごとに Google Sheets の URL または file ID を **手入力** し、`PATCH /api/locations/:id` で `spreadsheetId` を保存する（`src/app/locations/page.tsx` L27-33, L81-98）。
+
+**改善後:** 画面上部で **Google Drive フォルダ（URL または folder ID）** を指定し「一覧取得」操作でフォルダ直下の **Google Spreadsheet のみ**（ファイル名 + ID）を取得。取得結果を拠点テーブルと組み合わせ、**ドロップダウン等で拠点ごとに紐付け** → 既存 API で `spreadsheetId`（file ID）を保存。売上取り込み等の下流連携は **変更なし**。
+
+**v1 スコープ（推奨）:**
+- 人的確認可能な UI（ドロップダウン選択）を主とする
+- ファイル名による自動マッチは **オプション**（「名前で提案」ボタン等）。完全自動のみは行わない
+- Shared drive は既存 `listDriveFilesByQuery` の `supportsAllDrives: true` パターンに合わせる
+
+**既存資産の再利用:**
+- `backend/src/lib/google-drive-client.ts` — `listDriveFilesByQuery`, `DriveFileRef`, `MIME_GOOGLE_SHEETS`
+- `backend/scripts/drive-folder-smoke.ts` — 手動検証の参考
+- UI コンポーネント `@/components/ui/select`（`YearMonthPicker.tsx` 等で使用中）
+
+---
+
+## FE (Frontend)
+
+### 1. Files need to edit:
+
+#### 1.1. File: `src/lib/google-drive-id.ts` (新規)
+
+##### 1.1.1. `extractFolderId` ユーティリティ
+
+フォルダ URL / raw ID の正規化を FE・BE で共通化できるよう、まず FE 側にユーティリティを追加する（BE でも同ロジックを mirror または共有可能なら backend にも追加）。
+
+**変更内容:**
+
+- `extractFolderId(input: string): string` を export
+- 対応パターン例:
+  - `https://drive.google.com/drive/folders/{id}`
+  - `https://drive.google.com/drive/u/0/folders/{id}`（ユーザー番号付き）
+  - `https://drive.google.com/open?id={id}`（folder として扱う場合）
+  - 空白トリム後の raw folder ID（英数字 `-_`）
+- マッチしない場合は trim した入力をそのまま返す（BE 側で 404/403 エラーに委ねる）
+- 単体テストは任意（Vitest 未導入の FE では手動確認で可）
+
+---
+
+#### 1.2. File: `src/app/locations/page.tsx`
+
+##### 1.2.1. フォルダ指定 + 一覧取得セクション（画面上部）
+
+拠点テーブルの **上** に、フォルダ入力と取得操作 UI を追加する。
+
+**既存コード** (line 186-204):
+
+- 見出し「拠点スプレッドシート設定」と説明文のみ
+- 説明は Sheets URL/ID の手入力前提
+
+**変更内容:**
+
+- state 追加:
+  - `folderInput: string` — フォルダ URL/ID 入力
+  - `folderFetchState: "idle" | "loading" | "success" | "error"`
+  - `folderFetchError: string | null`
+  - `availableSpreadsheets: { id: string; name: string }[]`
+- UI ブロック（`canEdit` 時のみ操作可能）:
+  - `Input` — フォルダ URL/ID
+  - `Button`「一覧取得」— `handleFetchSpreadsheets`
+  - ローディング中は `Loader2` spinner
+  - 取得成功時: 取得件数 + 折りたたみ可能な一覧（ファイル名, ID の monospace 表示）
+  - 失敗時: `AlertCircle` + ユーザー向けメッセージ（権限不足・フォルダ未共有・設定不備等）
+- `handleFetchSpreadsheets`:
+  ```ts
+  const folderId = extractFolderId(folderInput);
+  const res = await fetchApi(`/api/drive/spreadsheets?folderId=${encodeURIComponent(folderId)}`);
+  ```
+- 説明文（L200-203）を更新:
+  - フォルダを SA（`client_email`）に **閲覧者** で共有する前提
+  - 従来の URL/ID 直接入力も **フォールバック** として残す旨
+
+##### 1.2.2. 拠点行 — ドロップダウン選択 UI
+
+一覧取得後、各行の Sheets 入力を **Select** に切り替え（または Select + 手入力の併用）。
+
+**既存コード** (line 250-259):
+
+- 全行 `Input` で URL/ID を自由入力
+- `extractSheetId` で保存時に ID 抽出
+
+**変更内容:**
+
+- `availableSpreadsheets.length > 0` のとき:
+  - `@/components/ui/select` でファイル選択
+  - 先頭 option: `未選択`（value `""`）
+  - 各 option: `{ name }` 表示、value = `{ id }`
+  - 同一 file を複数拠点に割当可能（issue 要件上禁止していない）だが、選択済み ID に `(他拠点で使用中)` バッジを付けると UX 向上
+- 一覧未取得時 or 手動上書きモード: 既存 `Input` を維持（トグル「手入力」リンクでも可）
+- `rowStates[loc.id].value` は引き続き **file ID**（または URL）を保持 — `handleSave` / `PATCH` フローは **変更なし**
+- Select 変更時: `handleValueChange(loc.id, selectedId)` で ID をセット
+
+##### 1.2.3. （オプション）名前による自動提案
+
+**変更内容:**
+
+- 「名前で自動提案」ボタン（一覧取得成功後、`canEdit` 時）
+- ルール（v1 最小）:
+  - `spreadsheet.name` に `location.name` が **部分一致** する最初の 1 件を提案
+  - 複数マッチ / 0 件はスキップし、結果サマリを toast またはインライン表示（例: 「3 拠点を提案、2 拠点は手動が必要」）
+- **自動保存はしない** — ユーザーが各行を確認してから「保存」
+
+##### 1.2.4. 保存・クリア・状態表示
+
+**既存コード** (line 81-184, 274-320):
+
+- `handleSave`, `handleClear`, `isDirty`, 状態バッジ（設定済/未設定/保存中）
+
+**変更内容:**
+
+- ロジックは基本維持。Select 選択後も `isDirty` が正しく動くよう `value` は常に file ID に正規化
+- テーブル列ヘッダを「Sheets ID / URL」→「スプレッドシート」等に変更（Select 主体の UI に合わせる）
+
+---
+
+## BE (Backend)
+
+### 1. Files need to edit:
+
+#### 1.1. File: `backend/src/lib/google-drive-client.ts`
+
+##### 1.1.1. `listSpreadsheetsInFolder(folderId)` 追加
+
+フォルダ直下の Google Spreadsheet のみを列挙する公開関数を追加する。
+
+**現在の実装** (line 121-142, 165-173):
+
+- `listDriveFilesByQuery` — ページネーション付き `files.list`、`supportsAllDrives: true`
+- `listSharedPlSpreadsheetFileRefs` — env フォルダ + ファイル名マーカー `損益計算資料` で絞り込み（本 issue とは別用途）
+
+**変更内容:**
+
+- 新規 export:
+  ```ts
+  export async function listSpreadsheetsInFolder(
+    folderId: string
+  ): Promise<DriveFileRef[]>
+  ```
+- `folderId` が空のとき throw: `[google-drive] listSpreadsheetsInFolder: empty folderId`
+- Drive query:
+  ```
+  '{folderId}' in parents and trashed = false and mimeType = '{MIME_GOOGLE_SHEETS}'
+  ```
+- `listDriveFilesByQuery(drive, q)` を再利用
+- 返却: `{ id, name }[]`、名前昇順ソート（UI 安定のため）
+- **Shared drive:** 既存 `listDriveFilesByQuery` の `supportsAllDrives` / `includeItemsFromAllDrives` で対応済み
+- **注記:** 運用で Drive 上の `.xlsx` アップロードも拠点 Sheet として使う場合、v2 で `mimeType = MIME_XLSX` を OR 条件に追加可能（v1 は issue 要件どおり native Spreadsheet のみ）
+
+##### 1.1.2. （任意）`extractDriveFolderId(input: string)`
+
+BE でも folder URL を受け付ける場合、FE と同ロジックの helper を追加。v1 では FE が ID を渡す前提でも可。
+
+---
+
+#### 1.2. File: `backend/src/routes/drive.ts` (新規)
+
+##### 1.2.1. `GET /api/drive/spreadsheets?folderId=`
+
+フォルダ内スプレッドシート一覧 API。
+
+**変更内容:**
+
+- `driveRouter = Router()`
+- `GET /spreadsheets`:
+  - `requireRole(ROLES.MASTER)` — locations PATCH と同等
+  - query: `folderId`（必須、Zod `z.string().trim().min(1)`）
+  - `listSpreadsheetsInFolder(folderId)` 呼び出し
+  - 成功: `200` + `{ spreadsheets: DriveFileRef[] }`
+  - エラーマッピング:
+    | Google / 内部 | HTTP | ユーザー向け `error` |
+    |---|---|---|
+    | `GOOGLE_SERVICE_ACCOUNT_JSON` 未設定 | 503 | サービスアカウントが設定されていません |
+    | 403 / insufficient permissions | 403 | フォルダがサービスアカウントと共有されていない可能性があります |
+    | 404 / not found | 404 | フォルダが見つかりません |
+    | その他 | 502 | Drive API の取得に失敗しました |
+  - サーバログ: `console.error` に `[drive/spreadsheets]` プレフィックス + 元エラー（開発者 trace 用）
+
+---
+
+#### 1.3. File: `backend/src/routes/index.ts`
+
+##### 1.3.1. drive ルーター登録
+
+**現在の実装** (line 50):
+
+- `apiRouter.use("/locations", locationsRouter);`
+
+**変更内容:**
+
+- `import { driveRouter } from "./drive.js";`
+- `apiRouter.use("/drive", requireRole(ROLES.MASTER), driveRouter);`
+- 認証は既存 `requireAuth` ミドルウェアでカバー済み
+
+---
+
+#### 1.4. File: `backend/src/lib/google-drive-client.test.ts`
+
+##### 1.4.1. `listSpreadsheetsInFolder` テスト追加
+
+**既存パターン** (line 281-324):
+
+- `listSharedPlSpreadsheetFileRefs` の mock テスト — `filesListMock`, `supportsAllDrives: true`
+
+**変更内容:**
+
+- empty folderId → throw
+- 正常系: query に `mimeType = 'application/vnd.google-apps.spreadsheet'` が含まれること
+- ページネーション: 2 ページ分を結合
+- Drive API エラーがそのまま reject されること
+
+---
+
+#### 1.5. File: `backend/src/routes/drive.test.ts` (新規、または contract test へ追加)
+
+##### 1.5.1. Route 契約テスト
+
+**変更内容:**
+
+- `supertest` + mock `listSpreadsheetsInFolder`
+- MASTER 未認証 → 401/403
+- `folderId` 欠落 → 400
+- 正常 → 200 + body shape
+- mock throw 403 → 適切な JSON error
+
+---
+
+#### 1.6. File: `backend/scripts/drive-folder-smoke.ts`
+
+##### 1.6.1. スプレッドシート一覧モード追加（任意）
+
+**現在の実装** (line 37-43):
+
+- フォルダ内 **全ファイル** を list（mime フィルタなし）
+
+**変更内容:**
+
+- CLI フラグ `--spreadsheets-only` または `listSpreadsheetsInFolder` 呼び出しを追加
+- 手動 QA: `npm run drive:smoke -- <FOLDER_ID>` で Spreadsheet のみ表示確認
+
+---
+
+#### 1.7. File: `backend/.env.example`
+
+##### 1.7.1. ヘルプコメント更新
+
+**変更内容:**
+
+- 拠点設定画面からフォルダ指定で一覧取得する運用を追記
+- 対象フォルダを SA `client_email` に **Viewer** で共有する手順を明記（既存 Drive コメントと整合）
+
+---
+
+## 実装順序 (Implementation Order)
+
+1. **Backend 実装**（Frontend の前提）
+
+   - 1.1.1 `listSpreadsheetsInFolder` in `google-drive-client.ts`
+   - 1.4.1 ユニットテスト
+   - 1.2.1 `drive.ts` route + 1.3.1 router 登録
+   - 1.5.1 route テスト
+   - 1.6.1 smoke script 更新（任意）
+   - 1.7.1 `.env.example` 更新
+
+2. **Frontend 実装**（Backend API 完成後）
+
+   - 1.1.1 `extractFolderId` utility
+   - 1.2.1 フォルダ入力 + 一覧取得 UI
+   - 1.2.2 ドロップダウン選択
+   - 1.2.3 名前自動提案（オプション、時間があれば）
+   - 1.2.4 説明文・列ヘッダ更新
+
+3. **統合テスト**
+
+   - フォルダ未共有 → FE に 403 メッセージ表示
+   - 一覧取得 → 拠点を Select → 保存 → `GET /api/locations` で `spreadsheetId` 反映
+   - 保存後: 既存売上 sync（`spreadsheet-revenue`）が従来どおり file ID で動作
+   - 非 MASTER ユーザー: `/locations` → forbidden（既存挙動維持）
+   - `npm test`（backend）全件パス
+
+---
+
+## 見積もり工数 (Estimated Effort)
+
+- **Backend**: 3–4 時間
+
+  - `listSpreadsheetsInFolder` + テスト: 1–1.5h
+  - `GET /api/drive/spreadsheets` + エラーマッピング + route テスト: 1.5–2h
+  - smoke / `.env.example`: 0.5h
+
+- **Frontend**: 4–5 時間
+
+  - `extractFolderId` + フォルダ取得 UI: 1.5h
+  - 行ごと Select + 既存 save フロー統合: 2h
+  - 名前自動提案（オプション）+ ヘルプ文案: 0.5–1.5h
+
+**合計**: 7–9 時間
+
+---
+
+## 技術的な注意事項 (Technical Notes)
+
+1. **パフォーマンス考慮:**
+
+   - フォルダ直下のみ（非再帰）— issue 要件「フォルダ直下（または運用で定める範囲）」に合わせ v1 は **直接の子** のみ
+   - `pageSize: 100` + ページネーションで大量ファイルにも対応（既存 `listDriveFilesByQuery`）
+   - 一覧結果は FE state のみ保持（DB 永続化不要）
+
+2. **UX 考慮:**
+
+   - 一覧取得前も手入力で設定可能（後方互換・例外対応）
+   - 権限エラーは「SA にフォルダを共有してください」等、**原因が分かる日本語**
+   - 同一 file の重複割当は警告表示のみ（ブロックは v1 では任意）
+   - Select 内の長いファイル名は truncate + title tooltip
+
+3. **データ整合性:**
+
+   - 保存値は従来どおり `Location.spreadsheetId`（Sheets file ID）
+   - フォルダ ID は DB に保存しない（画面セッションのみ）
+   - PATCH API・Prisma schema **変更不要**
+
+4. **既存機能との互換性:**
+
+   - `spreadsheet-revenue.ts` / scheduler — `Location.spreadsheetId` 経由の連携は無変更
+   - `listSharedPlSpreadsheetFileRefs`（損益計算資料 + env フォルダ）— 別経路、影響なし
+   - `locationsRouter.patch` — 変更なし
+   - Shared drive: 既存 `supportsAllDrives: true` パターンを踏襲
+
+5. **API 設計メモ:**
+
+   - エンドポイント案: `GET /api/drive/spreadsheets?folderId={id}`
+   - 代替案 `GET /api/locations/spreadsheets?folderId=` も可能だが、Drive 操作は `/api/drive` に分離する方が責務が明確
+
+6. **セキュリティ:**
+
+   - MASTER 権限必須（locations 設定画面と同等）
+   - folderId はユーザー入力 — Drive query は `driveQueryLiteral` でエスケープ済み
+   - SA は `drive.readonly` のみ（書き込み不可）

--- a/docs/issues/vehicle-pl-system/58/dev.md
+++ b/docs/issues/vehicle-pl-system/58/dev.md
@@ -1,0 +1,117 @@
+# Issue #58 — Development Log
+
+**Issue:** [BE] 拠点SS設定: Driveフォルダ内Spreadsheet一覧API  
+**URL:** https://github.com/TeckVeho/vehicle-pl-system/issues/58  
+**Parent:** [#57](https://github.com/TeckVeho/vehicle-pl-system/issues/57) — 拠点スプレッドシート設定（Frontend は別 issue）  
+**Branch:** (uncommitted — dev phase)  
+**Date:** 2026-05-21
+
+---
+
+## Requirements Summary
+
+Implement backend layer for location spreadsheet configuration:
+
+- `listSpreadsheetsInFolder(folderId)` in `google-drive-client.ts`
+- `GET /api/drive/spreadsheets?folderId=` (MASTER only)
+- Error mapping: SA unset → 503, permission → 403, not found → 404, other → 502
+- Register `/drive` router in `routes/index.ts`
+- Unit + route contract tests
+- Optional smoke script mode + `.env.example` comments
+- **No changes** to `PATCH /api/locations/:id` or Prisma schema
+
+---
+
+## Approach
+
+**Direct implementation** (not TDD-first): followed existing patterns from `listSharedPlSpreadsheetFileRefs`, `sync-routes.contract.test.ts`, and parent plan `docs/issues/vehicle-pl-system/57/plan.md` § BE.
+
+---
+
+## Changes Made
+
+### 1. `backend/src/lib/google-drive-client.ts`
+
+- Added `listSpreadsheetsInFolder(folderId)`:
+  - Throws on empty `folderId`
+  - Reuses `listDriveFilesByQuery` with query:
+    `'{folderId}' in parents and trashed = false and mimeType = 'application/vnd.google-apps.spreadsheet'`
+  - Sorts results by name ascending (`localeCompare("ja")`)
+  - Shared drive support inherited from existing list helper
+
+### 2. `backend/src/routes/drive.ts` (new)
+
+- `GET /spreadsheets` with Zod query validation (`folderId` required)
+- `mapDriveSpreadsheetsError()` maps Google / internal errors to user-facing JSON
+- Server log prefix: `[drive/spreadsheets]`
+
+### 3. `backend/src/routes/index.ts`
+
+- Registered: `apiRouter.use("/drive", requireRole(ROLES.MASTER), driveRouter)`
+
+### 4. Tests
+
+- `google-drive-client.test.ts`: empty folderId, query shape, pagination, error propagation
+- `drive.test.ts`: auth 401, role 403, missing param 400, success 200, 503/403/404/502 error mapping
+
+### 5. `backend/scripts/drive-folder-smoke.ts`
+
+- Added `--spreadsheets-only` flag using `listSpreadsheetsInFolder`
+
+### 6. `backend/.env.example`
+
+- Documented folder sharing for location spreadsheet settings UI (`GET /api/drive/spreadsheets`)
+
+---
+
+## Validation
+
+```bash
+cd backend && npm test
+```
+
+**Result:** 12 test files, **120 tests passed** (including 8 new drive route tests + 4 new client tests).
+
+---
+
+## API Contract
+
+```
+GET /api/drive/spreadsheets?folderId={id}
+Authorization: MASTER role (DX / DX管理者)
+
+200 OK
+{ "spreadsheets": [{ "id": string, "name": string }] }
+
+400 — folderId is required
+403 — フォルダがサービスアカウントと共有されていない可能性があります
+404 — フォルダが見つかりません
+503 — サービスアカウントが設定されていません
+502 — Drive API の取得に失敗しました
+```
+
+---
+
+## Out of Scope (per issue)
+
+- Frontend (`/locations` UI) — separate FE issue
+- `PATCH /api/locations/:id` changes
+- Prisma schema changes
+- `.xlsx` upload files in folder (v1 = native Google Sheets only)
+
+---
+
+## Manual Smoke (optional)
+
+```bash
+cd backend
+npm run drive:smoke -- --spreadsheets-only <FOLDER_ID>
+```
+
+Requires `GOOGLE_SERVICE_ACCOUNT_JSON` and folder shared with SA `client_email` as Viewer.
+
+---
+
+## Git Status
+
+Changes intentionally **left uncommitted** per `/dev` workflow — ready for `/test` and review.

--- a/docs/issues/vehicle-pl-system/59/dev.md
+++ b/docs/issues/vehicle-pl-system/59/dev.md
@@ -1,0 +1,92 @@
+# Issue #59 — Development Log
+
+**Issue:** [FE] 拠点SS設定: フォルダ指定UI・ドロップダウン紐付け  
+**URL:** https://github.com/TeckVeho/vehicle-pl-system/issues/59  
+**Parent:** [#57](https://github.com/TeckVeho/vehicle-pl-system/issues/57)  
+**Backend dependency:** [#58](https://github.com/TeckVeho/vehicle-pl-system/issues/58) — `GET /api/drive/spreadsheets`  
+**Date:** 2026-05-21
+
+---
+
+## Requirements Summary
+
+- `extractFolderId()` utility for Drive folder URL / raw ID
+- Top-of-page folder input +「一覧取得」→ `GET /api/drive/spreadsheets?folderId=`
+- Collapsible list of fetched spreadsheets (name + ID)
+- Per-location `Select` when list fetched; `Input` fallback otherwise
+- Optional「名前で自動提案」— partial match on `location.name` in file name (no auto-save)
+- Updated help text (SA folder share Viewer, manual fallback)
+- User-facing Japanese errors from API (403, 404, 503, 502)
+- Preserve `handleSave`, `handleClear`, `extractSheetId`, `PATCH /api/locations/:id`, dirty/save states
+
+---
+
+## Approach
+
+**Direct implementation** (no FE Vitest). Followed parent plan `docs/issues/vehicle-pl-system/57/plan.md` § FE and patterns from `users/page.tsx` (Select), `dashboard/page.tsx` (`<details>` collapsible).
+
+---
+
+## Changes Made
+
+### 1. `src/lib/google-drive-id.ts` (new)
+
+- `extractFolderId(input)`:
+  - `/folders/{id}` (including `/drive/u/N/folders/`)
+  - `open?id={id}`
+  - Trimmed raw ID fallback
+
+### 2. `src/app/locations/page.tsx`
+
+- **Folder section** (`canEdit` only): folder `Input`,「一覧取得」, loading spinner, error display, success count + `<details>` file list
+- **State:** `folderInput`, `folderFetchState`, `folderFetchError`, `availableSpreadsheets`, `manualInputRows`, `suggestSummary`
+- **Row UI:** `Select` when list loaded; per-row「手入力で設定」/「一覧から選択」toggle; orphan saved ID shown in dropdown
+- **UX:** `(他拠点で使用中)` via other locations’ draft `value`
+- **「名前で自動提案」:** `spreadsheet.name.includes(location.name)` — updates row values only, user must save
+- **Help text:** SA Viewer share + manual URL/ID fallback
+- **Column header:** 「スプレッドシート」
+- Unchanged: `extractSheetId`, `handleSave`, `handleClear`, `isDirty`, PATCH body
+
+### 3. `docs/issues/vehicle-pl-system/59/issue.md`
+
+- Issue metadata stub for `/dev` workflow
+
+---
+
+## Validation
+
+```bash
+cd /var/www/html/vehicle-pl-system && npm run lint
+```
+
+- `locations/page.tsx`: no errors after renaming `shouldUseDropdown` (avoid `use*` hook lint false positive)
+- Pre-existing warnings in other files unchanged
+
+**Manual / integration (requires running app + BE #58):**
+
+1. MASTER user opens `/locations`
+2. Share Drive folder with SA; paste folder URL →「一覧取得」
+3. Confirm count + collapsible list
+4. Select spreadsheet per location →「保存」→ DB `spreadsheetId` = file ID
+5. Without fetch: manual `Input` still works
+6. Trigger 403 (unshared folder) → Japanese error from API
+7.「名前で自動提案」→ dirty rows, no auto-save
+8. Save/clear/dirty badges unchanged
+
+---
+
+## Troubleshooting (2026-05-21)
+
+**Symptom:** Folder `16kmJirn_UeDcTix2RowdEwxxKRItTh9T` returned「0 件」despite 13 files visible in Drive.
+
+**Cause:** Folder contains only uploaded `.xlsx` (`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`), not native Google Sheets. v1 API query filtered `mimeType = spreadsheet` only.
+
+**Fix (BE):** `listSpreadsheetsInFolder` now includes both native Sheets and `.xlsx` (same as `downloadDriveFileAsXlsxBuffer`). Smoke: 13 files listed after change.
+
+**Note:** Dropdown lists all spreadsheet-like files in the folder (損益計算資料 + 運行表, etc.). User selects the correct file per location.
+
+---
+
+## Git Status
+
+Changes intentionally **left uncommitted** per `/dev` workflow — ready for `/test` and review.

--- a/docs/issues/vehicle-pl-system/59/issue.md
+++ b/docs/issues/vehicle-pl-system/59/issue.md
@@ -1,0 +1,15 @@
+# Issue #59
+
+**Title:** [FE] 拠点SS設定: フォルダ指定UI・ドロップダウン紐付け  
+**URL:** https://github.com/TeckVeho/vehicle-pl-system/issues/59  
+**Repository:** TeckVeho/vehicle-pl-system  
+**Parent:** [#57](https://github.com/TeckVeho/vehicle-pl-system/issues/57)  
+**Labels:** enhancement, frontend
+
+## Summary
+
+拠点スプレッドシート設定（`/locations`）に Drive フォルダ指定 → 一覧取得 → 拠点ごとドロップダウン紐付け UI を追加。保存は既存 `PATCH /api/locations/:id`（`spreadsheetId` = file ID）。
+
+## Dependencies
+
+- Backend [#58](https://github.com/TeckVeho/vehicle-pl-system/issues/58): `GET /api/drive/spreadsheets?folderId=`

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -3,10 +3,25 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { fetchApi } from "@/lib/api";
+import { extractFolderId } from "@/lib/google-drive-id";
 import { useAuthStore, canManageMaster } from "@/stores/authStore";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Database, Loader2, CheckCircle2, CircleDashed, AlertCircle } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Database,
+  Loader2,
+  CheckCircle2,
+  CircleDashed,
+  AlertCircle,
+  FolderOpen,
+} from "lucide-react";
 import { YearMonthPicker } from "@/components/common/YearMonthPicker";
 
 interface Location {
@@ -16,7 +31,13 @@ interface Location {
   spreadsheetId: string | null;
 }
 
+interface SpreadsheetRef {
+  id: string;
+  name: string;
+}
+
 type SaveState = "idle" | "saving" | "success" | "error";
+type FolderFetchState = "idle" | "loading" | "success" | "error";
 
 interface RowState {
   value: string;
@@ -24,12 +45,20 @@ interface RowState {
   errorMessage: string | null;
 }
 
+const SELECT_NONE = "__none__";
+
 function extractSheetId(input: string): string {
   const trimmed = input.trim();
-  // URLからIDを抽出 (https://docs.google.com/spreadsheets/d/{id}/...)
   const match = trimmed.match(/\/spreadsheets\/d\/([a-zA-Z0-9_-]+)/);
   if (match) return match[1];
   return trimmed;
+}
+
+function findSpreadsheetByLocationName(
+  spreadsheets: SpreadsheetRef[],
+  locationName: string
+): SpreadsheetRef | undefined {
+  return spreadsheets.find((s) => s.name.includes(locationName));
 }
 
 export default function LocationsPage() {
@@ -40,6 +69,18 @@ export default function LocationsPage() {
   const [locations, setLocations] = useState<Location[]>([]);
   const [loading, setLoading] = useState(true);
   const [rowStates, setRowStates] = useState<Record<string, RowState>>({});
+
+  const [folderInput, setFolderInput] = useState("");
+  const [folderFetchState, setFolderFetchState] =
+    useState<FolderFetchState>("idle");
+  const [folderFetchError, setFolderFetchError] = useState<string | null>(null);
+  const [availableSpreadsheets, setAvailableSpreadsheets] = useState<
+    SpreadsheetRef[]
+  >([]);
+  const [manualInputRows, setManualInputRows] = useState<Record<string, boolean>>(
+    {}
+  );
+  const [suggestSummary, setSuggestSummary] = useState<string | null>(null);
 
   useEffect(() => {
     if (!loadingAuth && user && !canManageMaster(user.role)) {
@@ -76,6 +117,76 @@ export default function LocationsPage() {
       ...prev,
       [locationId]: { ...prev[locationId], value, saveState: "idle", errorMessage: null },
     }));
+  };
+
+  const handleFetchSpreadsheets = async () => {
+    if (!canEdit) return;
+    const folderId = extractFolderId(folderInput);
+    if (!folderId) {
+      setFolderFetchState("error");
+      setFolderFetchError("フォルダ URL またはフォルダ ID を入力してください");
+      setAvailableSpreadsheets([]);
+      return;
+    }
+
+    setFolderFetchState("loading");
+    setFolderFetchError(null);
+    setSuggestSummary(null);
+
+    try {
+      const res = await fetchApi(
+        `/api/drive/spreadsheets?folderId=${encodeURIComponent(folderId)}`
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(
+          (err as { error?: string }).error ?? "一覧の取得に失敗しました"
+        );
+      }
+      const data = (await res.json()) as { spreadsheets: SpreadsheetRef[] };
+      setAvailableSpreadsheets(data.spreadsheets ?? []);
+      setFolderFetchState("success");
+      setManualInputRows({});
+    } catch (e) {
+      setAvailableSpreadsheets([]);
+      setFolderFetchState("error");
+      setFolderFetchError(
+        e instanceof Error ? e.message : "一覧の取得に失敗しました"
+      );
+    }
+  };
+
+  const handleSuggestByName = () => {
+    if (availableSpreadsheets.length === 0) return;
+    let suggested = 0;
+    let skipped = 0;
+
+    setRowStates((prev) => {
+      const next = { ...prev };
+      for (const loc of locations) {
+        const match = findSpreadsheetByLocationName(
+          availableSpreadsheets,
+          loc.name
+        );
+        if (match) {
+          next[loc.id] = {
+            ...next[loc.id],
+            value: match.id,
+            saveState: "idle",
+            errorMessage: null,
+          };
+          suggested++;
+        } else {
+          skipped++;
+        }
+      }
+      return next;
+    });
+
+    setManualInputRows({});
+    setSuggestSummary(
+      `${suggested} 拠点を提案しました。${skipped} 拠点は手動での設定が必要です。内容を確認してから各行の「保存」を押してください。`
+    );
   };
 
   const handleSave = async (locationId: string) => {
@@ -115,7 +226,6 @@ export default function LocationsPage() {
         },
       }));
 
-      // 3秒後にsuccess状態をリセット
       setTimeout(() => {
         setRowStates((prev) => ({
           ...prev,
@@ -183,6 +293,122 @@ export default function LocationsPage() {
     return currentExtracted !== (loc.spreadsheetId ?? null);
   };
 
+  const shouldUseDropdown = (locationId: string) =>
+    availableSpreadsheets.length > 0 && !manualInputRows[locationId];
+
+  const getOtherLocationsUsingSheet = (
+    locationId: string,
+    spreadsheetId: string
+  ): string[] => {
+    if (!spreadsheetId) return [];
+    return locations
+      .filter((l) => {
+        if (l.id === locationId) return false;
+        const otherValue = rowStates[l.id]?.value ?? "";
+        return extractSheetId(otherValue) === spreadsheetId;
+      })
+      .map((l) => l.name);
+  };
+
+  const renderSheetInput = (loc: Location) => {
+    const row = rowStates[loc.id];
+    const disabled = row?.saveState === "saving";
+
+    if (!canEdit) {
+      return (
+        <span className="font-mono text-sm text-foreground">
+          {loc.spreadsheetId ?? (
+            <span className="text-muted-foreground italic">未設定</span>
+          )}
+        </span>
+      );
+    }
+
+    if (shouldUseDropdown(loc.id)) {
+      const currentId = extractSheetId(row?.value ?? "");
+      const selectValue = currentId || SELECT_NONE;
+      const orphanId =
+        currentId &&
+        !availableSpreadsheets.some((s) => s.id === currentId)
+          ? currentId
+          : null;
+
+      return (
+        <div className="space-y-1">
+          <Select
+            value={selectValue}
+            onValueChange={(v) =>
+              handleValueChange(loc.id, v === SELECT_NONE ? "" : v)
+            }
+            disabled={disabled}
+          >
+            <SelectTrigger className="font-mono text-sm">
+              <SelectValue placeholder="スプレッドシートを選択" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={SELECT_NONE}>未選択</SelectItem>
+              {orphanId && (
+                <SelectItem value={orphanId}>
+                  （現在の設定）{orphanId}
+                </SelectItem>
+              )}
+              {availableSpreadsheets.map((s) => {
+                const usedBy = getOtherLocationsUsingSheet(loc.id, s.id);
+                const suffix =
+                  usedBy.length > 0
+                    ? `（${usedBy.join("、")} で使用中）`
+                    : "";
+                return (
+                  <SelectItem key={s.id} value={s.id}>
+                    {s.name}
+                    {suffix}
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
+          <button
+            type="button"
+            className="text-xs text-primary hover:underline"
+            onClick={() =>
+              setManualInputRows((prev) => ({ ...prev, [loc.id]: true }))
+            }
+          >
+            手入力で設定
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-1">
+        <Input
+          type="text"
+          value={row?.value ?? ""}
+          onChange={(e) => handleValueChange(loc.id, e.target.value)}
+          placeholder="Sheets ID または Google Sheets URL を貼り付け"
+          className="font-mono text-sm"
+          disabled={disabled}
+        />
+        {availableSpreadsheets.length > 0 && (
+          <button
+            type="button"
+            className="text-xs text-primary hover:underline"
+            onClick={() =>
+              setManualInputRows((prev) => {
+                const next = { ...prev };
+                delete next[loc.id];
+                return next;
+              })
+            }
+          >
+            一覧から選択
+          </button>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div className="min-h-screen">
       <div className="mb-10">
@@ -198,10 +424,108 @@ export default function LocationsPage() {
           <YearMonthPicker />
         </div>
         <p className="text-[15px] text-muted-foreground ml-[60px] leading-relaxed">
-          各拠点の売上データを参照する Google Sheets ID を設定します。
-          URL（<code className="text-xs bg-muted px-1 py-0.5 rounded">https://docs.google.com/spreadsheets/d/...</code>）または Sheets ID をそのまま入力できます。
+          各拠点の売上データを参照する Google スプレッドシートを設定します。
+          Google Drive のフォルダをサービスアカウント（閲覧者）に共有したうえで、フォルダから一覧を取得して紐付けできます。
+          一覧を取得しない場合は、従来どおり Sheets の URL（
+          <code className="text-xs bg-muted px-1 py-0.5 rounded">
+            https://docs.google.com/spreadsheets/d/...
+          </code>
+          ）または file ID を直接入力できます。
         </p>
       </div>
+
+      {canEdit && (
+        <div className="mb-8 rounded-2xl border border-border bg-card p-5 shadow-sm">
+          <div className="flex items-center gap-2 mb-3">
+            <FolderOpen className="h-5 w-5 text-primary" />
+            <h2 className="text-base font-semibold text-foreground">
+              Drive フォルダから一覧取得
+            </h2>
+          </div>
+          <p className="text-sm text-muted-foreground mb-4">
+            フォルダ URL（
+            <code className="text-xs bg-muted px-1 py-0.5 rounded">
+              https://drive.google.com/drive/folders/...
+            </code>
+            ）またはフォルダ ID を入力し、フォルダ内のスプレッドシート（Google シートおよび .xlsx）一覧を取得します。
+          </p>
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="flex-1 min-w-[240px]">
+              <Input
+                type="text"
+                value={folderInput}
+                onChange={(e) => {
+                  setFolderInput(e.target.value);
+                  if (folderFetchState === "error") {
+                    setFolderFetchState("idle");
+                    setFolderFetchError(null);
+                  }
+                }}
+                placeholder="Drive フォルダ URL またはフォルダ ID"
+                className="font-mono text-sm"
+                disabled={folderFetchState === "loading"}
+              />
+            </div>
+            <Button
+              onClick={handleFetchSpreadsheets}
+              disabled={folderFetchState === "loading" || !folderInput.trim()}
+            >
+              {folderFetchState === "loading" ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  取得中...
+                </>
+              ) : (
+                "一覧取得"
+              )}
+            </Button>
+            {folderFetchState === "success" && availableSpreadsheets.length > 0 && (
+              <Button variant="outline" onClick={handleSuggestByName}>
+                名前で自動提案
+              </Button>
+            )}
+          </div>
+
+          {folderFetchState === "error" && folderFetchError && (
+            <p className="text-sm text-destructive mt-3 flex items-center gap-1.5">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {folderFetchError}
+            </p>
+          )}
+
+          {suggestSummary && (
+            <p className="text-sm text-muted-foreground mt-3">{suggestSummary}</p>
+          )}
+
+          {folderFetchState === "success" && (
+            <div className="mt-4 text-sm text-foreground">
+              <p className="font-medium">
+                {availableSpreadsheets.length} 件のスプレッドシートを取得しました
+              </p>
+              {availableSpreadsheets.length > 0 && (
+                <details className="mt-2">
+                  <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+                    取得一覧を表示
+                  </summary>
+                  <ul className="mt-2 max-h-48 overflow-y-auto rounded-lg border border-border divide-y divide-border/60">
+                    {availableSpreadsheets.map((s) => (
+                      <li
+                        key={s.id}
+                        className="px-3 py-2 flex flex-wrap gap-x-3 gap-y-0.5"
+                      >
+                        <span className="font-medium">{s.name}</span>
+                        <span className="font-mono text-xs text-muted-foreground">
+                          {s.id}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {loading ? (
         <div className="flex items-center gap-3 py-12 text-muted-foreground">
@@ -221,7 +545,7 @@ export default function LocationsPage() {
                   拠点
                 </th>
                 <th className="px-5 py-4 text-left text-sm font-semibold text-foreground">
-                  Sheets ID / URL
+                  スプレッドシート
                 </th>
                 <th className="px-5 py-4 text-left text-sm font-semibold text-foreground w-[120px]">
                   状態
@@ -248,22 +572,7 @@ export default function LocationsPage() {
                       {loc.name}
                     </td>
                     <td className="px-5 py-3">
-                      {canEdit ? (
-                        <Input
-                          type="text"
-                          value={row?.value ?? ""}
-                          onChange={(e) => handleValueChange(loc.id, e.target.value)}
-                          placeholder="Sheets ID または Google Sheets URL を貼り付け"
-                          className="font-mono text-sm"
-                          disabled={row?.saveState === "saving"}
-                        />
-                      ) : (
-                        <span className="font-mono text-sm text-foreground">
-                          {loc.spreadsheetId ?? (
-                            <span className="text-muted-foreground italic">未設定</span>
-                          )}
-                        </span>
-                      )}
+                      {renderSheetInput(loc)}
                       {row?.saveState === "error" && row.errorMessage && (
                         <p className="text-xs text-destructive mt-1 flex items-center gap-1">
                           <AlertCircle className="h-3 w-3 shrink-0" />

--- a/src/lib/google-drive-id.ts
+++ b/src/lib/google-drive-id.ts
@@ -1,0 +1,16 @@
+/**
+ * Google Drive フォルダ URL / raw ID から folder ID を抽出する。
+ * マッチしない場合は trim した入力をそのまま返す（API 側で 404/403 等に委ねる）。
+ */
+export function extractFolderId(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return trimmed;
+
+  const foldersMatch = trimmed.match(/\/folders\/([a-zA-Z0-9_-]+)/);
+  if (foldersMatch) return foldersMatch[1];
+
+  const openIdMatch = trimmed.match(/[?&]id=([a-zA-Z0-9_-]+)/);
+  if (openIdMatch) return openIdMatch[1];
+
+  return trimmed;
+}


### PR DESCRIPTION
Closes #57 

## Summary

- **Backend (#58):** Add `GET /api/drive/spreadsheets?folderId=` (MASTER only) via `listSpreadsheetsInFolder`, listing native Google Sheets and uploaded `.xlsx` files in a shared Drive folder, with user-facing error mapping (403/404/503/502).
- **Frontend (#59):** Update `/locations` with folder URL/ID input, spreadsheet list fetch, per-location dropdown selection, optional name-based suggestions, and manual URL/ID fallback.
- **Utility:** Add `extractFolderId()` for Drive folder URL normalization.
- **Fix:** Include `.xlsx` uploads in folder listing (production folders use uploaded workbooks, not native Sheets).

Parent: #57

## Test plan

- [ ] `cd backend && npm test` — all tests pass (120+)
- [ ] MASTER user opens `/locations`, shares Drive folder with SA (Viewer), enters folder ID/URL →「一覧取得」returns file list
- [ ] Select spreadsheet per location →「保存」→ `spreadsheetId` saved as file ID
- [ ] Without list fetch, manual URL/ID input still works
- [ ] Unshared folder shows Japanese permission error (403)
- [ ]「名前で自動提案」suggests matches without auto-save
- [ ] Smoke: `npm run drive:smoke -- --spreadsheets-only <FOLDER_ID>`


Made with [Cursor](https://cursor.com)